### PR TITLE
Adds Source-specific options + other changes

### DIFF
--- a/lib/app_sources/fdroid.dart
+++ b/lib/app_sources/fdroid.dart
@@ -1,5 +1,6 @@
 import 'package:html/parser.dart';
 import 'package:http/http.dart';
+import 'package:obtainium/components/generated_form.dart';
 import 'package:obtainium/providers/source_provider.dart';
 
 class FDroid implements AppSource {
@@ -17,7 +18,8 @@ class FDroid implements AppSource {
   }
 
   @override
-  Future<APKDetails> getLatestAPKDetails(String standardUrl) async {
+  Future<APKDetails> getLatestAPKDetails(
+      String standardUrl, List<String>? additionalData) async {
     Response res = await get(Uri.parse(standardUrl));
     if (res.statusCode == 200) {
       var latestReleaseDiv =
@@ -46,4 +48,10 @@ class FDroid implements AppSource {
   AppNames getAppNames(String standardUrl) {
     return AppNames('F-Droid', Uri.parse(standardUrl).pathSegments.last);
   }
+
+  @override
+  List<List<GeneratedFormItem>> additionalDataFormItems = [];
+
+  @override
+  List<String> additionalDataDefaults = [];
 }

--- a/lib/app_sources/fdroid.dart
+++ b/lib/app_sources/fdroid.dart
@@ -12,14 +12,14 @@ class FDroid implements AppSource {
     RegExp standardUrlRegEx = RegExp('^https?://$host/[^/]+/packages/[^/]+');
     RegExpMatch? match = standardUrlRegEx.firstMatch(url.toLowerCase());
     if (match == null) {
-      throw notValidURL;
+      throw notValidURL(runtimeType.toString());
     }
     return url.substring(0, match.end);
   }
 
   @override
   Future<APKDetails> getLatestAPKDetails(
-      String standardUrl, List<String>? additionalData) async {
+      String standardUrl, List<String> additionalData) async {
     Response res = await get(Uri.parse(standardUrl));
     if (res.statusCode == 200) {
       var latestReleaseDiv =

--- a/lib/app_sources/github.dart
+++ b/lib/app_sources/github.dart
@@ -123,5 +123,5 @@ class GitHub implements AppSource {
   ];
 
   @override
-  List<String> additionalDataDefaults = ["true", "", ""];
+  List<String> additionalDataDefaults = ["true", "true", ""];
 }

--- a/lib/app_sources/github.dart
+++ b/lib/app_sources/github.dart
@@ -12,14 +12,15 @@ class GitHub implements AppSource {
     RegExp standardUrlRegEx = RegExp('^https?://$host/[^/]+/[^/]+');
     RegExpMatch? match = standardUrlRegEx.firstMatch(url.toLowerCase());
     if (match == null) {
-      throw notValidURL;
+      throw notValidURL(runtimeType.toString());
     }
     return url.substring(0, match.end);
   }
 
   @override
   Future<APKDetails> getLatestAPKDetails(
-      String standardUrl, List<String>? additionalData) async {
+      String standardUrl, List<String> additionalData) async {
+    // TODO: use additionalData
     Response res = await get(Uri.parse(
         'https://api.$host/repos${standardUrl.substring('https://$host'.length)}/releases'));
     if (res.statusCode == 200) {
@@ -86,5 +87,5 @@ class GitHub implements AppSource {
   ];
 
   @override
-  List<String> additionalDataDefaults = ["", ""];
+  List<String> additionalDataDefaults = ["", "", ""];
 }

--- a/lib/app_sources/github.dart
+++ b/lib/app_sources/github.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:http/http.dart';
+import 'package:obtainium/components/generated_form.dart';
 import 'package:obtainium/providers/source_provider.dart';
 
 class GitHub implements AppSource {
@@ -17,7 +18,8 @@ class GitHub implements AppSource {
   }
 
   @override
-  Future<APKDetails> getLatestAPKDetails(String standardUrl) async {
+  Future<APKDetails> getLatestAPKDetails(
+      String standardUrl, List<String>? additionalData) async {
     Response res = await get(Uri.parse(
         'https://api.$host/repos${standardUrl.substring('https://$host'.length)}/releases'));
     if (res.statusCode == 200) {
@@ -67,4 +69,18 @@ class GitHub implements AppSource {
     List<String> names = temp.substring(temp.indexOf('/') + 1).split('/');
     return AppNames(names[0], names[1]);
   }
+
+  @override
+  List<List<GeneratedFormItem>> additionalDataFormItems = [
+    [GeneratedFormItem(label: "Include Prereleases", type: FormItemType.bool)],
+    [
+      GeneratedFormItem(
+          label: "Filter APKs by Regular Expression",
+          type: FormItemType.string,
+          required: false)
+    ]
+  ];
+
+  @override
+  List<String> additionalDataDefaults = ["", ""];
 }

--- a/lib/app_sources/github.dart
+++ b/lib/app_sources/github.dart
@@ -72,7 +72,11 @@ class GitHub implements AppSource {
 
   @override
   List<List<GeneratedFormItem>> additionalDataFormItems = [
-    [GeneratedFormItem(label: "Include Prereleases", type: FormItemType.bool)],
+    [GeneratedFormItem(label: "Include prereleases", type: FormItemType.bool)],
+    [
+      GeneratedFormItem(
+          label: "Fallback to older releases", type: FormItemType.bool)
+    ],
     [
       GeneratedFormItem(
           label: "Filter APKs by Regular Expression",

--- a/lib/app_sources/github.dart
+++ b/lib/app_sources/github.dart
@@ -31,11 +31,6 @@ class GitHub implements AppSource {
         'https://api.$host/repos${standardUrl.substring('https://$host'.length)}/releases'));
     if (res.statusCode == 200) {
       var releases = jsonDecode(res.body) as List<dynamic>;
-      // TODO: Loop through each release and pick the latest one that matches:
-      //        The regex if any
-      //        The prerelease/not if any
-      //        Only latest if fallback is false
-      //        Will remain w zero or one release
 
       List<String> getReleaseAPKUrls(dynamic release) =>
           (release['assets'] as List<dynamic>?)

--- a/lib/app_sources/gitlab.dart
+++ b/lib/app_sources/gitlab.dart
@@ -1,6 +1,7 @@
 import 'package:html/parser.dart';
 import 'package:http/http.dart';
 import 'package:obtainium/app_sources/github.dart';
+import 'package:obtainium/components/generated_form.dart';
 import 'package:obtainium/providers/source_provider.dart';
 
 class GitLab implements AppSource {
@@ -18,7 +19,8 @@ class GitLab implements AppSource {
   }
 
   @override
-  Future<APKDetails> getLatestAPKDetails(String standardUrl) async {
+  Future<APKDetails> getLatestAPKDetails(
+      String standardUrl, List<String>? additionalData) async {
     Response res = await get(Uri.parse('$standardUrl/-/tags?format=atom'));
     if (res.statusCode == 200) {
       var standardUri = Uri.parse(standardUrl);
@@ -60,4 +62,10 @@ class GitLab implements AppSource {
     // Same as GitHub
     return GitHub().getAppNames(standardUrl);
   }
+
+  @override
+  List<List<GeneratedFormItem>> additionalDataFormItems = [];
+
+  @override
+  List<String> additionalDataDefaults = [];
 }

--- a/lib/app_sources/gitlab.dart
+++ b/lib/app_sources/gitlab.dart
@@ -13,14 +13,14 @@ class GitLab implements AppSource {
     RegExp standardUrlRegEx = RegExp('^https?://$host/[^/]+/[^/]+');
     RegExpMatch? match = standardUrlRegEx.firstMatch(url.toLowerCase());
     if (match == null) {
-      throw notValidURL;
+      throw notValidURL(runtimeType.toString());
     }
     return url.substring(0, match.end);
   }
 
   @override
   Future<APKDetails> getLatestAPKDetails(
-      String standardUrl, List<String>? additionalData) async {
+      String standardUrl, List<String> additionalData) async {
     Response res = await get(Uri.parse('$standardUrl/-/tags?format=atom'));
     if (res.statusCode == 200) {
       var standardUri = Uri.parse(standardUrl);

--- a/lib/app_sources/izzyondroid.dart
+++ b/lib/app_sources/izzyondroid.dart
@@ -1,5 +1,6 @@
 import 'package:html/parser.dart';
 import 'package:http/http.dart';
+import 'package:obtainium/components/generated_form.dart';
 import 'package:obtainium/providers/source_provider.dart';
 
 class IzzyOnDroid implements AppSource {
@@ -17,7 +18,8 @@ class IzzyOnDroid implements AppSource {
   }
 
   @override
-  Future<APKDetails> getLatestAPKDetails(String standardUrl) async {
+  Future<APKDetails> getLatestAPKDetails(
+      String standardUrl, List<String>? additionalData) async {
     Response res = await get(Uri.parse(standardUrl));
     if (res.statusCode == 200) {
       var parsedHtml = parse(res.body);
@@ -54,4 +56,10 @@ class IzzyOnDroid implements AppSource {
   AppNames getAppNames(String standardUrl) {
     return AppNames('IzzyOnDroid', Uri.parse(standardUrl).pathSegments.last);
   }
+
+  @override
+  List<List<GeneratedFormItem>> additionalDataFormItems = [];
+
+  @override
+  List<String> additionalDataDefaults = [];
 }

--- a/lib/app_sources/izzyondroid.dart
+++ b/lib/app_sources/izzyondroid.dart
@@ -12,14 +12,14 @@ class IzzyOnDroid implements AppSource {
     RegExp standardUrlRegEx = RegExp('^https?://$host/repo/apk/[^/]+');
     RegExpMatch? match = standardUrlRegEx.firstMatch(url.toLowerCase());
     if (match == null) {
-      throw notValidURL;
+      throw notValidURL(runtimeType.toString());
     }
     return url.substring(0, match.end);
   }
 
   @override
   Future<APKDetails> getLatestAPKDetails(
-      String standardUrl, List<String>? additionalData) async {
+      String standardUrl, List<String> additionalData) async {
     Response res = await get(Uri.parse(standardUrl));
     if (res.statusCode == 200) {
       var parsedHtml = parse(res.body);

--- a/lib/app_sources/mullvad.dart
+++ b/lib/app_sources/mullvad.dart
@@ -1,5 +1,6 @@
 import 'package:html/parser.dart';
 import 'package:http/http.dart';
+import 'package:obtainium/components/generated_form.dart';
 import 'package:obtainium/providers/source_provider.dart';
 
 class Mullvad implements AppSource {
@@ -17,7 +18,8 @@ class Mullvad implements AppSource {
   }
 
   @override
-  Future<APKDetails> getLatestAPKDetails(String standardUrl) async {
+  Future<APKDetails> getLatestAPKDetails(
+      String standardUrl, List<String>? additionalData) async {
     Response res = await get(Uri.parse('$standardUrl/en/download/android'));
     if (res.statusCode == 200) {
       var version = parse(res.body)
@@ -40,4 +42,10 @@ class Mullvad implements AppSource {
   AppNames getAppNames(String standardUrl) {
     return AppNames('Mullvad-VPN', 'Mullvad-VPN');
   }
+
+  @override
+  List<List<GeneratedFormItem>> additionalDataFormItems = [];
+
+  @override
+  List<String> additionalDataDefaults = [];
 }

--- a/lib/app_sources/mullvad.dart
+++ b/lib/app_sources/mullvad.dart
@@ -12,14 +12,14 @@ class Mullvad implements AppSource {
     RegExp standardUrlRegEx = RegExp('^https?://$host');
     RegExpMatch? match = standardUrlRegEx.firstMatch(url.toLowerCase());
     if (match == null) {
-      throw notValidURL;
+      throw notValidURL(runtimeType.toString());
     }
     return url.substring(0, match.end);
   }
 
   @override
   Future<APKDetails> getLatestAPKDetails(
-      String standardUrl, List<String>? additionalData) async {
+      String standardUrl, List<String> additionalData) async {
     Response res = await get(Uri.parse('$standardUrl/en/download/android'));
     if (res.statusCode == 200) {
       var version = parse(res.body)

--- a/lib/app_sources/signal.dart
+++ b/lib/app_sources/signal.dart
@@ -14,7 +14,7 @@ class Signal implements AppSource {
 
   @override
   Future<APKDetails> getLatestAPKDetails(
-      String standardUrl, List<String>? additionalData) async {
+      String standardUrl, List<String> additionalData) async {
     Response res =
         await get(Uri.parse('https://updates.$host/android/latest.json'));
     if (res.statusCode == 200) {

--- a/lib/app_sources/signal.dart
+++ b/lib/app_sources/signal.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:http/http.dart';
+import 'package:obtainium/components/generated_form.dart';
 import 'package:obtainium/providers/source_provider.dart';
 
 class Signal implements AppSource {
@@ -12,7 +13,8 @@ class Signal implements AppSource {
   }
 
   @override
-  Future<APKDetails> getLatestAPKDetails(String standardUrl) async {
+  Future<APKDetails> getLatestAPKDetails(
+      String standardUrl, List<String>? additionalData) async {
     Response res =
         await get(Uri.parse('https://updates.$host/android/latest.json'));
     if (res.statusCode == 200) {
@@ -33,4 +35,10 @@ class Signal implements AppSource {
 
   @override
   AppNames getAppNames(String standardUrl) => AppNames('Signal', 'Signal');
+
+  @override
+  List<List<GeneratedFormItem>> additionalDataFormItems = [];
+
+  @override
+  List<String> additionalDataDefaults = [];
 }

--- a/lib/components/generated_form.dart
+++ b/lib/components/generated_form.dart
@@ -9,12 +9,14 @@ class GeneratedFormItem {
   late FormItemType type;
   late bool required;
   late int max;
+  late List<String? Function(String? value)> additionalValidators;
 
   GeneratedFormItem(
       {this.label = "Input",
       this.type = FormItemType.string,
       this.required = true,
-      this.max = 1});
+      this.max = 1,
+      this.additionalValidators = const []});
 }
 
 class GeneratedForm extends StatefulWidget {
@@ -91,8 +93,14 @@ class _GeneratedFormState extends State<GeneratedForm> {
             minLines: e.value.max <= 1 ? null : e.value.max,
             maxLines: e.value.max <= 1 ? 1 : e.value.max,
             validator: (value) {
-              if (value == null || value.isEmpty) {
+              if (value == null || value.trim().isEmpty) {
                 return '${e.value.label} (required)';
+              }
+              for (var validator in e.value.additionalValidators) {
+                String? result = validator(value);
+                if (result != null) {
+                  return result;
+                }
               }
               return null;
             },

--- a/lib/components/generated_form.dart
+++ b/lib/components/generated_form.dart
@@ -140,9 +140,11 @@ class _GeneratedFormState extends State<GeneratedForm> {
       if (rowInputs.key > 0) {
         rows.add([
           SizedBox(
-            height: widget.items[rowInputs.key][0].type == FormItemType.bool
+            height: widget.items[rowInputs.key][0].type == FormItemType.bool &&
+                    widget.items[rowInputs.key - 1][0].type ==
+                        FormItemType.string
                 ? 25
-                : 4,
+                : 8,
           )
         ]);
       }

--- a/lib/components/generated_form.dart
+++ b/lib/components/generated_form.dart
@@ -5,12 +5,16 @@ enum FormItemType { string, bool }
 typedef OnValueChanges = void Function(List<List<String?>> values, bool valid);
 
 class GeneratedFormItem {
-  late String label = "Input";
-  late FormItemType type = FormItemType.string;
-  late bool required = true;
-  late int max = 1;
+  late String label;
+  late FormItemType type;
+  late bool required;
+  late int max;
 
-  GeneratedFormItem(this.label, this.type, this.required, this.max);
+  GeneratedFormItem(
+      {this.label = "Input",
+      this.type = FormItemType.string,
+      this.required = true,
+      this.max = 1});
 }
 
 class GeneratedForm extends StatefulWidget {
@@ -54,15 +58,12 @@ class _GeneratedFormState extends State<GeneratedForm> {
             someValueChanged();
           });
           return TextFormField(
-              decoration: InputDecoration(helperText: e.value.label),
+              decoration: InputDecoration(
+                  helperText: e.value.label + (e.value.required ? " *" : "")),
               controller: controller,
               minLines: e.value.max <= 1 ? null : e.value.max,
               maxLines: e.value.max <= 1 ? 1 : e.value.max,
               validator: (value) {
-                // print(value);
-                // print(value?.isEmpty);
-                // print(value?.length);
-                // print(value == null);
                 if (value == null || value.isEmpty) {
                   return '${e.value.label} (required)';
                 }
@@ -71,32 +72,39 @@ class _GeneratedFormState extends State<GeneratedForm> {
               // : null,
               );
         } else {
-          return Switch(
-              value: values[row.key][e.key]?.isEmpty ?? false,
-              onChanged: (value) {
-                values[row.key][e.key] = value ? "true" : "";
-                someValueChanged();
-              });
+          return Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(e.value.label),
+                Switch(
+                    value: values[row.key][e.key]?.isEmpty ?? false,
+                    onChanged: (value) {
+                      values[row.key][e.key] = value ? "true" : "";
+                      someValueChanged();
+                    })
+              ]);
         }
       }).toList();
     }).toList();
 
     formInputs.asMap().entries.forEach((rowInputs) {
-      if (rowInputs.key > 0 && rowInputs.key < formInputs.length - 1) {
+      if (rowInputs.key > 0) {
         rows.add([
-          const SizedBox(
-            height: 8,
+          SizedBox(
+            height: widget.items[rowInputs.key][0].type == FormItemType.bool
+                ? 25
+                : 4,
           )
         ]);
       }
       List<Widget> rowItems = [];
       rowInputs.value.asMap().entries.forEach((rowInput) {
-        if (rowInput.key > 0 && rowInput.key < rowInputs.value.length) {
+        if (rowInput.key > 0) {
           rowItems.add(const SizedBox(
-            width: 8,
+            width: 20,
           ));
         }
-        rowItems.add(rowInput.value);
+        rowItems.add(Expanded(child: rowInput.value));
       });
       rows.add(rowItems);
     });
@@ -109,7 +117,9 @@ class _GeneratedFormState extends State<GeneratedForm> {
         child: Column(
           children: [
             ...rows.map((row) => Row(
-                  children: [...row.map((e) => Expanded(child: e))],
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [...row.map((e) => e)],
                 ))
           ],
         ));

--- a/lib/components/generated_form.dart
+++ b/lib/components/generated_form.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+
+enum FormItemType { string, bool }
+
+typedef OnValueChanges = void Function(List<List<String?>> values, bool valid);
+
+class GeneratedFormItem {
+  late String label = "Input";
+  late FormItemType type = FormItemType.string;
+  late bool required = true;
+  late int max = 1;
+
+  GeneratedFormItem(this.label, this.type, this.required, this.max);
+}
+
+class GeneratedForm extends StatefulWidget {
+  const GeneratedForm(
+      {super.key, required this.items, required this.onValueChanges});
+
+  final List<List<GeneratedFormItem>> items;
+  final OnValueChanges onValueChanges;
+
+  @override
+  State<GeneratedForm> createState() => _GeneratedFormState();
+}
+
+class _GeneratedFormState extends State<GeneratedForm> {
+  final _formKey = GlobalKey<FormState>();
+  late List<List<String?>> values;
+  late List<List<Widget>> formInputs;
+  List<List<Widget>> rows = [];
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Initialize form values as all empty
+    values = widget.items.map((row) => row.map((e) => "").toList()).toList();
+
+    // If any value changes, call this to update the parent with value and validity
+    void someValueChanged() {
+      widget.onValueChanges(values, _formKey.currentState?.validate() ?? false);
+    }
+
+    // Dynamically create form inputs
+    formInputs = widget.items.asMap().entries.map((row) {
+      return row.value.asMap().entries.map((e) {
+        if (e.value.type == FormItemType.string) {
+          final controller =
+              TextEditingController(text: values[row.key][e.key]);
+          controller.addListener(() {
+            // Each time an input value changes, update the results and send to parent
+            values[row.key][e.key] = controller.value.text;
+            someValueChanged();
+          });
+          return TextFormField(
+              decoration: InputDecoration(helperText: e.value.label),
+              controller: controller,
+              minLines: e.value.max <= 1 ? null : e.value.max,
+              maxLines: e.value.max <= 1 ? 1 : e.value.max,
+              validator: (value) {
+                // print(value);
+                // print(value?.isEmpty);
+                // print(value?.length);
+                // print(value == null);
+                if (value == null || value.isEmpty) {
+                  return '${e.value.label} (required)';
+                }
+                return null;
+              }
+              // : null,
+              );
+        } else {
+          return Switch(
+              value: values[row.key][e.key]?.isEmpty ?? false,
+              onChanged: (value) {
+                values[row.key][e.key] = value ? "true" : "";
+                someValueChanged();
+              });
+        }
+      }).toList();
+    }).toList();
+
+    formInputs.asMap().entries.forEach((rowInputs) {
+      if (rowInputs.key > 0 && rowInputs.key < formInputs.length - 1) {
+        rows.add([
+          const SizedBox(
+            height: 8,
+          )
+        ]);
+      }
+      List<Widget> rowItems = [];
+      rowInputs.value.asMap().entries.forEach((rowInput) {
+        if (rowInput.key > 0 && rowInput.key < rowInputs.value.length) {
+          rowItems.add(const SizedBox(
+            width: 8,
+          ));
+        }
+        rowItems.add(rowInput.value);
+      });
+      rows.add(rowItems);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+        key: _formKey,
+        child: Column(
+          children: [
+            ...rows.map((row) => Row(
+                  children: [...row.map((e) => Expanded(child: e))],
+                ))
+          ],
+        ));
+  }
+}

--- a/lib/components/generated_form.dart
+++ b/lib/components/generated_form.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 enum FormItemType { string, bool }
 
-typedef OnValueChanges = void Function(List<String?> values, bool valid);
+typedef OnValueChanges = void Function(List<String> values, bool valid);
 
 class GeneratedFormItem {
   late String label;
@@ -54,7 +54,7 @@ class _GeneratedFormState extends State<GeneratedForm> {
 
     // If any value changes, call this to update the parent with value and validity
     void someValueChanged() {
-      List<String?> returnValues = [];
+      List<String> returnValues = [];
       var valid = true;
       for (int r = 0; r < values.length; r++) {
         for (int i = 0; i < values[r].length; i++) {

--- a/lib/components/generated_form.dart
+++ b/lib/components/generated_form.dart
@@ -40,6 +40,25 @@ class _GeneratedFormState extends State<GeneratedForm> {
   late List<List<Widget>> formInputs;
   List<List<Widget>> rows = [];
 
+  // If any value changes, call this to update the parent with value and validity
+  void someValueChanged() {
+    List<String> returnValues = [];
+    var valid = true;
+    for (int r = 0; r < values.length; r++) {
+      for (int i = 0; i < values[r].length; i++) {
+        returnValues.add(values[r][i]);
+        if (formInputs[r][i] is TextFormField) {
+          valid = valid &&
+              ((formInputs[r][i].key as GlobalKey<FormFieldState>)
+                      .currentState
+                      ?.isValid ??
+                  false);
+        }
+      }
+    }
+    widget.onValueChanges(returnValues, valid);
+  }
+
   @override
   void initState() {
     super.initState();
@@ -53,25 +72,6 @@ class _GeneratedFormState extends State<GeneratedForm> {
                   : "";
             }).toList())
         .toList();
-
-    // If any value changes, call this to update the parent with value and validity
-    void someValueChanged() {
-      List<String> returnValues = [];
-      var valid = true;
-      for (int r = 0; r < values.length; r++) {
-        for (int i = 0; i < values[r].length; i++) {
-          returnValues.add(values[r][i]);
-          if (formInputs[r][i] is TextFormField) {
-            valid = valid &&
-                ((formInputs[r][i].key as GlobalKey<FormFieldState>)
-                        .currentState
-                        ?.isValid ??
-                    false);
-          }
-        }
-      }
-      widget.onValueChanges(returnValues, valid);
-    }
 
     // Dynamically create form inputs
     formInputs = widget.items.asMap().entries.map((row) {
@@ -93,7 +93,7 @@ class _GeneratedFormState extends State<GeneratedForm> {
             minLines: e.value.max <= 1 ? null : e.value.max,
             maxLines: e.value.max <= 1 ? 1 : e.value.max,
             validator: (value) {
-              if (value == null || value.trim().isEmpty) {
+              if (e.value.required && (value == null || value.trim().isEmpty)) {
                 return '${e.value.label} (required)';
               }
               for (var validator in e.value.additionalValidators) {
@@ -106,20 +106,7 @@ class _GeneratedFormState extends State<GeneratedForm> {
             },
           );
         } else {
-          return Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(e.value.label),
-              Switch(
-                  value: values[row.key][e.key] != "",
-                  onChanged: (value) {
-                    setState(() {
-                      values[row.key][e.key] = value ? "true" : "";
-                      someValueChanged();
-                    });
-                  })
-            ],
-          );
+          return Container(); // Some input types added in build
         }
       }).toList();
     }).toList();
@@ -127,6 +114,27 @@ class _GeneratedFormState extends State<GeneratedForm> {
 
   @override
   Widget build(BuildContext context) {
+    for (var r = 0; r < formInputs.length; r++) {
+      for (var e = 0; e < formInputs[r].length; e++) {
+        if (widget.items[r][e].type == FormItemType.bool) {
+          formInputs[r][e] = Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(widget.items[r][e].label),
+              Switch(
+                  value: values[r][e] == "true",
+                  onChanged: (value) {
+                    setState(() {
+                      values[r][e] = value ? "true" : "";
+                      someValueChanged();
+                    });
+                  })
+            ],
+          );
+        }
+      }
+    }
+
     rows.clear();
     formInputs.asMap().entries.forEach((rowInputs) {
       if (rowInputs.key > 0) {

--- a/lib/components/generated_form.dart
+++ b/lib/components/generated_form.dart
@@ -55,11 +55,6 @@ class _GeneratedFormState extends State<GeneratedForm> {
     // If any value changes, call this to update the parent with value and validity
     void someValueChanged() {
       List<String?> returnValues = [];
-      for (var row in values) {
-        for (var element in row) {
-          returnValues.add(element);
-        }
-      }
       var valid = true;
       for (int r = 0; r < values.length; r++) {
         for (int i = 0; i < values[r].length; i++) {

--- a/lib/components/generated_form.dart
+++ b/lib/components/generated_form.dart
@@ -40,7 +40,10 @@ class _GeneratedFormState extends State<GeneratedForm> {
 
     // Initialize form values as all empty
     values = widget.items.map((row) => row.map((e) => "").toList()).toList();
+  }
 
+  @override
+  Widget build(BuildContext context) {
     // If any value changes, call this to update the parent with value and validity
     void someValueChanged() {
       widget.onValueChanges(values, _formKey.currentState?.validate() ?? false);
@@ -50,43 +53,45 @@ class _GeneratedFormState extends State<GeneratedForm> {
     formInputs = widget.items.asMap().entries.map((row) {
       return row.value.asMap().entries.map((e) {
         if (e.value.type == FormItemType.string) {
-          final controller =
-              TextEditingController(text: values[row.key][e.key]);
-          controller.addListener(() {
-            // Each time an input value changes, update the results and send to parent
-            values[row.key][e.key] = controller.value.text;
-            someValueChanged();
-          });
           return TextFormField(
-              decoration: InputDecoration(
-                  helperText: e.value.label + (e.value.required ? " *" : "")),
-              controller: controller,
-              minLines: e.value.max <= 1 ? null : e.value.max,
-              maxLines: e.value.max <= 1 ? 1 : e.value.max,
-              validator: (value) {
-                if (value == null || value.isEmpty) {
-                  return '${e.value.label} (required)';
-                }
-                return null;
+            initialValue: values[row.key][e.key],
+            onChanged: (value) {
+              setState(() {
+                values[row.key][e.key] = value;
+                someValueChanged();
+              });
+            },
+            decoration: InputDecoration(
+                helperText: e.value.label + (e.value.required ? " *" : "")),
+            minLines: e.value.max <= 1 ? null : e.value.max,
+            maxLines: e.value.max <= 1 ? 1 : e.value.max,
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return '${e.value.label} (required)';
               }
-              // : null,
-              );
+              return null;
+            },
+          );
         } else {
           return Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text(e.value.label),
-                Switch(
-                    value: values[row.key][e.key]?.isEmpty ?? false,
-                    onChanged: (value) {
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(e.value.label),
+              Switch(
+                  value: values[row.key][e.key] != "",
+                  onChanged: (value) {
+                    setState(() {
                       values[row.key][e.key] = value ? "true" : "";
                       someValueChanged();
-                    })
-              ]);
+                    });
+                  })
+            ],
+          );
         }
       }).toList();
     }).toList();
 
+    rows.clear();
     formInputs.asMap().entries.forEach((rowInputs) {
       if (rowInputs.key > 0) {
         rows.add([
@@ -108,10 +113,7 @@ class _GeneratedFormState extends State<GeneratedForm> {
       });
       rows.add(rowItems);
     });
-  }
 
-  @override
-  Widget build(BuildContext context) {
     return Form(
         key: _formKey,
         child: Column(

--- a/lib/components/generated_form_modal.dart
+++ b/lib/components/generated_form_modal.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-class GeneratedFormItem {
-  late String message;
+class GeneratedFormModalItem {
+  late String label;
   late bool required;
-  late int lines;
+  late int max;
 
-  GeneratedFormItem(this.message, this.required, this.lines);
+  GeneratedFormModalItem(this.label, this.required, this.max);
 }
 
 class GeneratedFormModal extends StatefulWidget {
@@ -14,7 +14,7 @@ class GeneratedFormModal extends StatefulWidget {
       {super.key, required this.title, required this.items});
 
   final String title;
-  final List<GeneratedFormItem> items;
+  final List<GeneratedFormModalItem> items;
 
   @override
   State<GeneratedFormModal> createState() => _GeneratedFormModalState();
@@ -23,8 +23,6 @@ class GeneratedFormModal extends StatefulWidget {
 class _GeneratedFormModalState extends State<GeneratedFormModal> {
   final _formKey = GlobalKey<FormState>();
 
-  final urlInputController = TextEditingController();
-
   @override
   Widget build(BuildContext context) {
     final formInputs = widget.items.map((e) {
@@ -32,14 +30,14 @@ class _GeneratedFormModalState extends State<GeneratedFormModal> {
       return [
         controller,
         TextFormField(
-          decoration: InputDecoration(helperText: e.message),
+          decoration: InputDecoration(helperText: e.label),
           controller: controller,
-          minLines: e.lines <= 1 ? null : e.lines,
-          maxLines: e.lines <= 1 ? 1 : e.lines,
+          minLines: e.max <= 1 ? null : e.max,
+          maxLines: e.max <= 1 ? 1 : e.max,
           validator: e.required
               ? (value) {
                   if (value == null || value.isEmpty) {
-                    return '${e.message} (required)';
+                    return '${e.label} (required)';
                   }
                   return null;
                 }

--- a/lib/components/generated_form_modal.dart
+++ b/lib/components/generated_form_modal.dart
@@ -55,5 +55,3 @@ class _GeneratedFormModalState extends State<GeneratedFormModal> {
     );
   }
 }
-
-// TODO: Add support for larger textarea so this can be used for text/json imports

--- a/lib/components/generated_form_modal.dart
+++ b/lib/components/generated_form_modal.dart
@@ -1,59 +1,40 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-
-class GeneratedFormModalItem {
-  late String label;
-  late bool required;
-  late int max;
-
-  GeneratedFormModalItem(this.label, this.required, this.max);
-}
+import 'package:obtainium/components/generated_form.dart';
 
 class GeneratedFormModal extends StatefulWidget {
   const GeneratedFormModal(
-      {super.key, required this.title, required this.items});
+      {super.key,
+      required this.title,
+      required this.items,
+      required this.defaultValues});
 
   final String title;
-  final List<GeneratedFormModalItem> items;
+  final List<List<GeneratedFormItem>> items;
+  final List<String> defaultValues;
 
   @override
   State<GeneratedFormModal> createState() => _GeneratedFormModalState();
 }
 
 class _GeneratedFormModalState extends State<GeneratedFormModal> {
-  final _formKey = GlobalKey<FormState>();
+  List<String> values = [];
+  bool valid = false;
 
   @override
   Widget build(BuildContext context) {
-    final formInputs = widget.items.map((e) {
-      final controller = TextEditingController();
-      return [
-        controller,
-        TextFormField(
-          decoration: InputDecoration(helperText: e.label),
-          controller: controller,
-          minLines: e.max <= 1 ? null : e.max,
-          maxLines: e.max <= 1 ? 1 : e.max,
-          validator: e.required
-              ? (value) {
-                  if (value == null || value.isEmpty) {
-                    return '${e.label} (required)';
-                  }
-                  return null;
-                }
-              : null,
-        )
-      ];
-    }).toList();
     return AlertDialog(
       scrollable: true,
       title: Text(widget.title),
-      content: Form(
-          key: _formKey,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [...formInputs.map((e) => e[1] as Widget)],
-          )),
+      content: GeneratedForm(
+          items: widget.items,
+          onValueChanges: (values, valid) {
+            setState(() {
+              this.values = values;
+              this.valid = valid;
+            });
+          },
+          defaultValues: widget.defaultValues),
       actions: [
         TextButton(
             onPressed: () {
@@ -61,14 +42,14 @@ class _GeneratedFormModalState extends State<GeneratedFormModal> {
             },
             child: const Text('Cancel')),
         TextButton(
-            onPressed: () {
-              if (_formKey.currentState?.validate() == true) {
-                HapticFeedback.selectionClick();
-                Navigator.of(context).pop(formInputs
-                    .map((e) => (e[0] as TextEditingController).value.text)
-                    .toList());
-              }
-            },
+            onPressed: !valid
+                ? null
+                : () {
+                    if (valid) {
+                      HapticFeedback.selectionClick();
+                      Navigator.of(context).pop(values);
+                    }
+                  },
             child: const Text('Continue'))
       ],
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,7 +59,7 @@ void main() async {
       ChangeNotifierProvider(
           create: (context) => AppsProvider(
               shouldLoadApps: true,
-              shouldCheckUpdatesAfterLoad: true,
+              shouldCheckUpdatesAfterLoad: false,
               shouldDeleteAPKs: true)),
       ChangeNotifierProvider(create: (context) => SettingsProvider()),
       Provider(create: (context) => NotificationsProvider())

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -103,7 +103,8 @@ class MyApp extends StatelessWidget {
             currentReleaseTag,
             currentReleaseTag,
             [],
-            0));
+            0,
+            [])); // TODO: Will need prerelease true here
       }
     }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -104,7 +104,7 @@ class MyApp extends StatelessWidget {
             currentReleaseTag,
             [],
             0,
-            [])); // TODO: Will need prerelease true here
+            ["true"]));
       }
     }
 

--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -66,9 +66,18 @@ class _AddAppPageState extends State<AddAppPage> {
                                   onValueChanges: (values, valid) {
                                     setState(() {
                                       userInput = values[0];
-                                      pickedSource = valid
+                                      var source = valid
                                           ? sourceProvider.getSource(userInput)
                                           : null;
+                                      if (pickedSource != source) {
+                                        pickedSource = source;
+                                        additionalData = [];
+                                        validAdditionalData = source != null
+                                            ? sourceProvider
+                                                .doesSourceHaveRequiredAdditionalData(
+                                                    source)
+                                            : true;
+                                      }
                                     });
                                   },
                                   defaultValues: const [])),

--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -49,7 +49,10 @@ class _AddAppPageState extends State<AddAppPage> {
                                             (value) {
                                               try {
                                                 sourceProvider
-                                                    .getSource(value ?? "");
+                                                    .getSource(value ?? "")
+                                                    .standardizeURL(
+                                                        makeUrlHttps(
+                                                            value ?? ""));
                                               } catch (e) {
                                                 return e is String
                                                     ? e
@@ -84,11 +87,9 @@ class _AddAppPageState extends State<AddAppPage> {
                                       setState(() {
                                         gettingAppInfo = true;
                                       });
-                                      AppSource source =
-                                          sourceProvider.getSource(userInput);
                                       sourceProvider
-                                          .getApp(
-                                              source, userInput, additionalData)
+                                          .getApp(pickedSource!, userInput,
+                                              additionalData)
                                           .then((app) {
                                         var appsProvider =
                                             context.read<AppsProvider>();

--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -70,9 +70,14 @@ class _AddAppPageState extends State<AddAppPage> {
                                             setState(() {
                                               gettingAppInfo = true;
                                             });
-                                            sourceProvider
-                                                .getApp(urlInputController
-                                                    .value.text)
+                                            AppSource source = sourceProvider
+                                                .getSource(urlInputController
+                                                    .value.text);
+                                            sourceProvider.getApp(
+                                                    source,
+                                                    urlInputController
+                                                        .value.text,
+                                                    []) // TODO: From form if any
                                                 .then((app) {
                                               var appsProvider =
                                                   context.read<AppsProvider>();

--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:obtainium/components/custom_app_bar.dart';
+import 'package:obtainium/components/generated_form.dart';
 import 'package:obtainium/pages/app.dart';
 import 'package:obtainium/providers/apps_provider.dart';
 import 'package:obtainium/providers/settings_provider.dart';
@@ -16,9 +17,12 @@ class AddAppPage extends StatefulWidget {
 }
 
 class _AddAppPageState extends State<AddAppPage> {
-  final _formKey = GlobalKey<FormState>();
-  final urlInputController = TextEditingController();
   bool gettingAppInfo = false;
+
+  String userInput = "";
+  AppSource? pickedSource;
+  List<String> additionalData = [];
+  bool validAdditionalData = false;
 
   @override
   Widget build(BuildContext context) {
@@ -28,136 +32,156 @@ class _AddAppPageState extends State<AddAppPage> {
         body: CustomScrollView(slivers: <Widget>[
           const CustomAppBar(title: 'Add App'),
           SliverFillRemaining(
-              hasScrollBody: false,
-              child: Center(
-                child: Form(
-                    key: _formKey,
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        Container(),
-                        Padding(
-                          padding: const EdgeInsets.all(16),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.stretch,
-                            children: [
-                              TextFormField(
-                                decoration: const InputDecoration(
-                                    hintText:
-                                        'https://github.com/Author/Project',
-                                    helperText: 'Enter the App source URL'),
-                                controller: urlInputController,
-                                validator: (value) {
-                                  if (value == null ||
-                                      value.isEmpty ||
-                                      Uri.tryParse(value) == null) {
-                                    return 'Please enter a supported source URL';
-                                  }
-                                  return null;
-                                },
-                              ),
-                              Padding(
-                                padding:
-                                    const EdgeInsets.symmetric(vertical: 16.0),
-                                child: ElevatedButton(
-                                  onPressed: gettingAppInfo
-                                      ? null
-                                      : () {
-                                          HapticFeedback.selectionClick();
-                                          if (_formKey.currentState!
-                                              .validate()) {
-                                            setState(() {
-                                              gettingAppInfo = true;
-                                            });
-                                            AppSource source = sourceProvider
-                                                .getSource(urlInputController
-                                                    .value.text);
-                                            sourceProvider.getApp(
-                                                    source,
-                                                    urlInputController
-                                                        .value.text,
-                                                    []) // TODO: From form if any
-                                                .then((app) {
-                                              var appsProvider =
-                                                  context.read<AppsProvider>();
-                                              var settingsProvider = context
-                                                  .read<SettingsProvider>();
-                                              if (appsProvider.apps
-                                                  .containsKey(app.id)) {
-                                                throw 'App already added';
+            child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                              child: GeneratedForm(
+                                  items: [
+                                    [
+                                      GeneratedFormItem(
+                                          label: "App Source Url",
+                                          additionalValidators: [
+                                            (value) {
+                                              try {
+                                                sourceProvider
+                                                    .getSource(value ?? "");
+                                              } catch (e) {
+                                                return e is String
+                                                    ? e
+                                                    : "Error";
                                               }
-                                              settingsProvider
-                                                  .getInstallPermission()
-                                                  .then((_) {
-                                                appsProvider
-                                                    .saveApp(app)
-                                                    .then((_) {
-                                                  urlInputController.clear();
-                                                  Navigator.push(
-                                                      context,
-                                                      MaterialPageRoute(
-                                                          builder: (context) =>
-                                                              AppPage(
-                                                                  appId:
-                                                                      app.id)));
-                                                });
-                                              });
-                                            }).catchError((e) {
-                                              ScaffoldMessenger.of(context)
-                                                  .showSnackBar(
-                                                SnackBar(
-                                                    content:
-                                                        Text(e.toString())),
-                                              );
-                                            }).whenComplete(() {
-                                              setState(() {
-                                                gettingAppInfo = false;
-                                              });
-                                            });
-                                          }
-                                        },
-                                  child: const Text('Add'),
-                                ),
-                              ),
-                            ],
+                                              return null;
+                                            }
+                                          ])
+                                    ]
+                                  ],
+                                  onValueChanges: (values, valid) {
+                                    setState(() {
+                                      userInput = values[0];
+                                      pickedSource = valid
+                                          ? sourceProvider.getSource(userInput)
+                                          : null;
+                                    });
+                                  },
+                                  defaultValues: const [])),
+                          const SizedBox(
+                            width: 16,
                           ),
-                        ),
+                          ElevatedButton(
+                              onPressed: gettingAppInfo ||
+                                      pickedSource == null ||
+                                      (pickedSource!.additionalDataFormItems
+                                              .isNotEmpty &&
+                                          !validAdditionalData)
+                                  ? null
+                                  : () {
+                                      HapticFeedback.selectionClick();
+                                      setState(() {
+                                        gettingAppInfo = true;
+                                      });
+                                      AppSource source =
+                                          sourceProvider.getSource(userInput);
+                                      sourceProvider
+                                          .getApp(
+                                              source, userInput, additionalData)
+                                          .then((app) {
+                                        var appsProvider =
+                                            context.read<AppsProvider>();
+                                        var settingsProvider =
+                                            context.read<SettingsProvider>();
+                                        if (appsProvider.apps
+                                            .containsKey(app.id)) {
+                                          throw 'App already added';
+                                        }
+                                        settingsProvider
+                                            .getInstallPermission()
+                                            .then((_) {
+                                          appsProvider.saveApp(app).then((_) {
+                                            Navigator.push(
+                                                context,
+                                                MaterialPageRoute(
+                                                    builder: (context) =>
+                                                        AppPage(
+                                                            appId: app.id)));
+                                          });
+                                        });
+                                      }).catchError((e) {
+                                        ScaffoldMessenger.of(context)
+                                            .showSnackBar(
+                                          SnackBar(content: Text(e.toString())),
+                                        );
+                                      }).whenComplete(() {
+                                        setState(() {
+                                          gettingAppInfo = false;
+                                        });
+                                      });
+                                    },
+                              child: const Text('Add'))
+                        ],
+                      ),
+                      if (pickedSource != null &&
+                          (pickedSource!.additionalDataFormItems.isNotEmpty))
                         Column(
-                            crossAxisAlignment: CrossAxisAlignment.center,
-                            children: [
-                              const Text(
-                                'Supported Sources:',
-                                // style: TextStyle(fontWeight: FontWeight.bold),
-                                // style: Theme.of(context).textTheme.bodySmall,
-                              ),
-                              const SizedBox(
-                                height: 8,
-                              ),
-                              ...sourceProvider
-                                  .getSourceHosts()
-                                  .map((e) => GestureDetector(
-                                      onTap: () {
-                                        launchUrlString('https://$e',
-                                            mode:
-                                                LaunchMode.externalApplication);
-                                      },
-                                      child: Text(
-                                        e,
-                                        style: const TextStyle(
-                                            decoration:
-                                                TextDecoration.underline,
-                                            fontStyle: FontStyle.italic),
-                                      )))
-                                  .toList()
-                            ]),
-                        if (gettingAppInfo)
-                          const LinearProgressIndicator()
-                        else
-                          Container(),
-                      ],
-                    )),
-              ))
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            const Divider(
+                              height: 64,
+                            ),
+                            Text(
+                                'Additional Options for ${pickedSource?.runtimeType}',
+                                style: TextStyle(
+                                    color:
+                                        Theme.of(context).colorScheme.primary)),
+                            const SizedBox(
+                              height: 16,
+                            ),
+                            GeneratedForm(
+                                items: pickedSource!.additionalDataFormItems,
+                                onValueChanges: (values, valid) {
+                                  setState(() {
+                                    additionalData = values;
+                                    validAdditionalData = valid;
+                                  });
+                                },
+                                defaultValues:
+                                    pickedSource!.additionalDataDefaults)
+                          ],
+                        ),
+                      // const SizedBox(
+                      //   height: 16,
+                      // ),
+                      // Column(
+                      //     crossAxisAlignment: CrossAxisAlignment.center,
+                      //     children: [
+                      //       const Text(
+                      //         'Supported Sources:',
+                      //       ),
+                      //       const SizedBox(
+                      //         height: 8,
+                      //       ),
+                      //       ...sourceProvider
+                      //           .getSourceHosts()
+                      //           .map((e) => GestureDetector(
+                      //               onTap: () {
+                      //                 launchUrlString('https://$e',
+                      //                     mode: LaunchMode.externalApplication);
+                      //               },
+                      //               child: Text(
+                      //                 e,
+                      //                 style: const TextStyle(
+                      //                     decoration: TextDecoration.underline,
+                      //                     fontStyle: FontStyle.italic),
+                      //               )))
+                      //           .toList()
+                      //     ]),
+                      // const Spacer(),
+                    ])),
+          )
         ]));
   }
 }

--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -22,7 +22,7 @@ class _AddAppPageState extends State<AddAppPage> {
   String userInput = "";
   AppSource? pickedSource;
   List<String> additionalData = [];
-  bool validAdditionalData = false;
+  bool validAdditionalData = true;
 
   @override
   Widget build(BuildContext context) {
@@ -124,14 +124,14 @@ class _AddAppPageState extends State<AddAppPage> {
                               child: const Text('Add'))
                         ],
                       ),
+                      const Divider(
+                        height: 64,
+                      ),
                       if (pickedSource != null &&
                           (pickedSource!.additionalDataFormItems.isNotEmpty))
                         Column(
                           crossAxisAlignment: CrossAxisAlignment.stretch,
                           children: [
-                            const Divider(
-                              height: 64,
-                            ),
                             Text(
                                 'Additional Options for ${pickedSource?.runtimeType}',
                                 style: TextStyle(
@@ -151,35 +151,39 @@ class _AddAppPageState extends State<AddAppPage> {
                                 defaultValues:
                                     pickedSource!.additionalDataDefaults)
                           ],
-                        ),
-                      // const SizedBox(
-                      //   height: 16,
-                      // ),
-                      // Column(
-                      //     crossAxisAlignment: CrossAxisAlignment.center,
-                      //     children: [
-                      //       const Text(
-                      //         'Supported Sources:',
-                      //       ),
-                      //       const SizedBox(
-                      //         height: 8,
-                      //       ),
-                      //       ...sourceProvider
-                      //           .getSourceHosts()
-                      //           .map((e) => GestureDetector(
-                      //               onTap: () {
-                      //                 launchUrlString('https://$e',
-                      //                     mode: LaunchMode.externalApplication);
-                      //               },
-                      //               child: Text(
-                      //                 e,
-                      //                 style: const TextStyle(
-                      //                     decoration: TextDecoration.underline,
-                      //                     fontStyle: FontStyle.italic),
-                      //               )))
-                      //           .toList()
-                      //     ]),
-                      // const Spacer(),
+                        )
+                      else
+                        Expanded(
+                            child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.center,
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                              // const SizedBox(
+                              //   height: 48,
+                              // ),
+                              const Text(
+                                'Supported Sources:',
+                              ),
+                              const SizedBox(
+                                height: 8,
+                              ),
+                              ...sourceProvider
+                                  .getSourceHosts()
+                                  .map((e) => GestureDetector(
+                                      onTap: () {
+                                        launchUrlString('https://$e',
+                                            mode:
+                                                LaunchMode.externalApplication);
+                                      },
+                                      child: Text(
+                                        e,
+                                        style: const TextStyle(
+                                            decoration:
+                                                TextDecoration.underline,
+                                            fontStyle: FontStyle.italic),
+                                      )))
+                                  .toList()
+                            ])),
                     ])),
           )
         ]));

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -5,6 +5,7 @@ import 'package:obtainium/pages/add_app.dart';
 import 'package:obtainium/pages/apps.dart';
 import 'package:obtainium/pages/import_export.dart';
 import 'package:obtainium/pages/settings.dart';
+import 'package:obtainium/pages/test_page.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -25,7 +26,7 @@ class _HomePageState extends State<HomePage> {
   List<int> selectedIndexHistory = [];
 
   List<NavigationPageItem> pages = [
-    NavigationPageItem('Apps', Icons.apps, const AppsPage()),
+    NavigationPageItem('Apps', Icons.apps, const TestPage()),
     NavigationPageItem('Add App', Icons.add, const AddAppPage()),
     NavigationPageItem(
         'Import/Export', Icons.import_export, const ImportExportPage()),

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -26,7 +26,7 @@ class _HomePageState extends State<HomePage> {
   List<int> selectedIndexHistory = [];
 
   List<NavigationPageItem> pages = [
-    NavigationPageItem('Apps', Icons.apps, const TestPage()),
+    NavigationPageItem('Apps', Icons.apps, const AppsPage()),
     NavigationPageItem('Add App', Icons.add, const AddAppPage()),
     NavigationPageItem(
         'Import/Export', Icons.import_export, const ImportExportPage()),

--- a/lib/pages/import_export.dart
+++ b/lib/pages/import_export.dart
@@ -167,7 +167,7 @@ class _ImportExportPageState extends State<ImportExportPage> {
                                         return GeneratedFormModal(
                                           title: 'Import from URL List',
                                           items: [
-                                            GeneratedFormItem(
+                                            GeneratedFormModalItem(
                                                 'App URL List', true, 7)
                                           ],
                                         );
@@ -231,7 +231,7 @@ class _ImportExportPageState extends State<ImportExportPage> {
                                                           items: source
                                                               .requiredArgs
                                                               .map((e) =>
-                                                                  GeneratedFormItem(
+                                                                  GeneratedFormModalItem(
                                                                       e,
                                                                       true,
                                                                       1))

--- a/lib/pages/import_export.dart
+++ b/lib/pages/import_export.dart
@@ -170,7 +170,29 @@ class _ImportExportPageState extends State<ImportExportPage> {
                                           items: [
                                             [
                                               GeneratedFormItem(
-                                                  label: 'App URL List', max: 7)
+                                                  label: 'App URL List',
+                                                  max: 7,
+                                                  additionalValidators: [
+                                                    (String? value) {
+                                                      if (value != null &&
+                                                          value.isNotEmpty) {
+                                                        var lines = value
+                                                            .trim()
+                                                            .split('\n');
+                                                        for (int i = 0;
+                                                            i < lines.length;
+                                                            i++) {
+                                                          try {
+                                                            sourceProvider
+                                                                .getSource(
+                                                                    lines[i]);
+                                                          } catch (e) {
+                                                            return 'Line ${i + 1}: $e';
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  ])
                                             ]
                                           ],
                                           defaultValues: const [],

--- a/lib/pages/import_export.dart
+++ b/lib/pages/import_export.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:obtainium/components/custom_app_bar.dart';
+import 'package:obtainium/components/generated_form.dart';
 import 'package:obtainium/components/generated_form_modal.dart';
 import 'package:obtainium/providers/apps_provider.dart';
 import 'package:obtainium/providers/settings_provider.dart';
@@ -167,9 +168,12 @@ class _ImportExportPageState extends State<ImportExportPage> {
                                         return GeneratedFormModal(
                                           title: 'Import from URL List',
                                           items: [
-                                            GeneratedFormModalItem(
-                                                'App URL List', true, 7)
+                                            [
+                                              GeneratedFormItem(
+                                                  label: 'App URL List', max: 7)
+                                            ]
                                           ],
+                                          defaultValues: const [],
                                         );
                                       }).then((values) {
                                     if (values != null) {
@@ -226,16 +230,17 @@ class _ImportExportPageState extends State<ImportExportPage> {
                                                     builder:
                                                         (BuildContext ctx) {
                                                       return GeneratedFormModal(
-                                                          title:
-                                                              'Import ${source.name}',
-                                                          items: source
-                                                              .requiredArgs
-                                                              .map((e) =>
-                                                                  GeneratedFormModalItem(
-                                                                      e,
-                                                                      true,
-                                                                      1))
-                                                              .toList());
+                                                        title:
+                                                            'Import ${source.name}',
+                                                        items: source
+                                                            .requiredArgs
+                                                            .map((e) => [
+                                                                  GeneratedFormItem(
+                                                                      label: e)
+                                                                ])
+                                                            .toList(),
+                                                        defaultValues: const [],
+                                                      );
                                                     }).then((values) {
                                                   if (values != null) {
                                                     source

--- a/lib/pages/test_page.dart
+++ b/lib/pages/test_page.dart
@@ -13,7 +13,12 @@ class _TestPageState extends State<TestPage> {
   bool valid = false;
 
   List<List<GeneratedFormItem>> sourceSpecificInputs = [
-    [GeneratedFormItem('Test Item', FormItemType.string, true, 1)]
+    [GeneratedFormItem(label: 'Test Item 1')],
+    [
+      GeneratedFormItem(label: 'Test Item 2', required: false),
+      GeneratedFormItem(label: 'Test Item 3')
+    ],
+    [GeneratedFormItem(label: 'Test Item 4', type: FormItemType.bool)]
   ];
 
   void onSourceSpecificDataChanges(
@@ -21,7 +26,11 @@ class _TestPageState extends State<TestPage> {
     setState(() {
       sourceSpecificData = valuesFromForm;
       valid = formValid;
-      print(sourceSpecificData?[0][0]);
+      sourceSpecificData?.forEach((row) {
+        for (var element in row) {
+          print(element);
+        }
+      });
     });
   }
 

--- a/lib/pages/test_page.dart
+++ b/lib/pages/test_page.dart
@@ -9,7 +9,7 @@ class TestPage extends StatefulWidget {
 }
 
 class _TestPageState extends State<TestPage> {
-  List<List<String?>>? sourceSpecificData;
+  List<String?>? sourceSpecificData;
   bool valid = false;
 
   List<List<GeneratedFormItem>> sourceSpecificInputs = [
@@ -21,16 +21,13 @@ class _TestPageState extends State<TestPage> {
     [GeneratedFormItem(label: 'Test Item 4', type: FormItemType.bool)]
   ];
 
+  List<String> defaultInputValues = ["ABC"];
+
   void onSourceSpecificDataChanges(
-      List<List<String?>> valuesFromForm, bool formValid) {
+      List<String?> valuesFromForm, bool formValid) {
     setState(() {
       sourceSpecificData = valuesFromForm;
       valid = formValid;
-      sourceSpecificData?.forEach((row) {
-        for (var element in row) {
-          print(element);
-        }
-      });
     });
   }
 
@@ -40,11 +37,17 @@ class _TestPageState extends State<TestPage> {
         appBar: AppBar(title: const Text('Test Page')),
         backgroundColor: Theme.of(context).colorScheme.surface,
         body: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: GeneratedForm(
-            items: sourceSpecificInputs,
-            onValueChanges: onSourceSpecificDataChanges,
-          ),
-        ));
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Column(children: [
+              GeneratedForm(
+                items: sourceSpecificInputs,
+                onValueChanges: onSourceSpecificDataChanges,
+                defaultValues: defaultInputValues,
+              ),
+              ...(sourceSpecificData != null
+                  ? (sourceSpecificData as List<String?>)
+                      .map((e) => Text(e ?? ""))
+                  : [Container()])
+            ])));
   }
 }

--- a/lib/pages/test_page.dart
+++ b/lib/pages/test_page.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:obtainium/components/generated_form.dart';
+
+class TestPage extends StatefulWidget {
+  const TestPage({super.key});
+
+  @override
+  State<TestPage> createState() => _TestPageState();
+}
+
+class _TestPageState extends State<TestPage> {
+  List<List<String?>>? sourceSpecificData;
+  bool valid = false;
+
+  List<List<GeneratedFormItem>> sourceSpecificInputs = [
+    [GeneratedFormItem('Test Item', FormItemType.string, true, 1)]
+  ];
+
+  void onSourceSpecificDataChanges(
+      List<List<String?>> valuesFromForm, bool formValid) {
+    setState(() {
+      sourceSpecificData = valuesFromForm;
+      valid = formValid;
+      print(sourceSpecificData?[0][0]);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(title: const Text('Test Page')),
+        backgroundColor: Theme.of(context).colorScheme.surface,
+        body: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: GeneratedForm(
+            items: sourceSpecificInputs,
+            onValueChanges: onSourceSpecificDataChanges,
+          ),
+        ));
+  }
+}

--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -228,7 +228,11 @@ class AppsProvider with ChangeNotifier {
 
   Future<App?> getUpdate(String appId) async {
     App? currentApp = apps[appId]!.app;
-    App newApp = await SourceProvider().getApp(currentApp.url);
+    SourceProvider sourceProvider = SourceProvider();
+    App newApp = await sourceProvider.getApp(
+        sourceProvider.getSource(currentApp.url),
+        currentApp.url,
+        currentApp.additionalData);
     if (newApp.latestVersion != currentApp.latestVersion) {
       newApp.installedVersion = currentApp.installedVersion;
       if (currentApp.preferredApkIndex < newApp.apkUrls.length) {

--- a/lib/providers/source_provider.dart
+++ b/lib/providers/source_provider.dart
@@ -103,7 +103,10 @@ makeUrlHttps(String url) {
 const String couldNotFindReleases = 'Unable to fetch release info';
 const String couldNotFindLatestVersion =
     'Could not determine latest release version';
-const String notValidURL = 'Not a valid URL';
+String notValidURL(String sourceName) {
+  return 'Not a valid $sourceName App URL';
+}
+
 const String noAPKFound = 'No APK found';
 
 List<String> getLinksFromParsedHTML(
@@ -121,7 +124,7 @@ abstract class AppSource {
   late String host;
   String standardizeURL(String url);
   Future<APKDetails> getLatestAPKDetails(
-      String standardUrl, List<String>? additionalData);
+      String standardUrl, List<String> additionalData);
   AppNames getAppNames(String standardUrl);
   late List<List<GeneratedFormItem>> additionalDataFormItems;
   late List<String>
@@ -188,8 +191,8 @@ class SourceProvider {
     Map<String, dynamic> errors = {};
     for (var url in urls) {
       try {
-        apps.add(await getApp(getSource(url), url,
-            [])); // TODO: additionalData should have defaults;
+        var source = getSource(url);
+        apps.add(await getApp(source, url, source.additionalDataDefaults));
       } catch (e) {
         errors.addAll(<String, dynamic>{url: e});
       }

--- a/lib/providers/source_provider.dart
+++ b/lib/providers/source_provider.dart
@@ -67,7 +67,7 @@ class App {
           : List<String>.from(jsonDecode(json['apkUrls'])),
       json['preferredApkIndex'] == null ? 0 : json['preferredApkIndex'] as int,
       json['additionalData'] == null
-          ? []
+          ? SourceProvider().getSource(json['url']).additionalDataDefaults
           : List<String>.from(jsonDecode(json['additionalData'])));
 
   Map<String, dynamic> toJson() => {
@@ -100,7 +100,7 @@ makeUrlHttps(String url) {
   return url;
 }
 
-const String couldNotFindReleases = 'Unable to fetch release info';
+const String couldNotFindReleases = 'Could not find a suitable release';
 const String couldNotFindLatestVersion =
     'Could not determine latest release version';
 String notValidURL(String sourceName) {
@@ -164,6 +164,17 @@ class SourceProvider {
       throw 'URL does not match a known source';
     }
     return source;
+  }
+
+  bool doesSourceHaveRequiredAdditionalData(AppSource source) {
+    for (var row in source.additionalDataFormItems) {
+      for (var element in row) {
+        if (element.required) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   Future<App> getApp(


### PR DESCRIPTION
1. Added a `GeneratedForm` class to generate forms dynamically from a `List` of requirements.
2. Added `additionalDataFormItems` to the `AppSource` class to enable the user to specify Source-specific options on an App by App basis.
3. Added the followin Source-specific options for GitHub Apps:
    1. Include pre-releases (`true` by default) - #18
    2. Fall back on older releases if the latest release has no APKs (`true` by default) - #22
    3. Filter releases by their titles using regular expressions - #20
4. Various bugfixes and tweaks (including for #17)