### PR TITLE
Real Package Names Used as IDs + App Icons (INCONVENIENT FOR PREVIOUS VERSION USERS)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -144,7 +144,7 @@ class _ObtainiumState extends State<Obtainium> {
         Permission.notification.request();
         appsProvider.saveApps([
           App(
-              'imranr98_obtainium_${GitHub().host}',
+              'dev.imranr.obtainium',
               'https://github.com/ImranR98/Obtainium',
               'ImranR98',
               'Obtainium',
@@ -153,9 +153,7 @@ class _ObtainiumState extends State<Obtainium> {
               [],
               0,
               ['true'],
-              null,
-              'dev.imranr.obtainium',
-              currentVersion)
+              null)
         ]);
       }
       // Register the background update task according to the user's setting

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:obtainium/app_sources/github.dart';
 import 'package:obtainium/custom_errors.dart';
 import 'package:obtainium/pages/home.dart';
 import 'package:obtainium/providers/apps_provider.dart';
@@ -13,7 +12,7 @@ import 'package:workmanager/workmanager.dart';
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 
-const String currentVersion = '0.5.10';
+const String currentVersion = '0.6.0';
 const String currentReleaseTag =
     'v$currentVersion-beta'; // KEEP THIS IN SYNC WITH GITHUB RELEASES
 

--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -90,56 +90,73 @@ class _AddAppPageState extends State<AddAppPage> {
                           const SizedBox(
                             width: 16,
                           ),
-                          ElevatedButton(
-                              onPressed: gettingAppInfo ||
-                                      pickedSource == null ||
-                                      (pickedSource!.additionalDataFormItems
-                                              .isNotEmpty &&
-                                          !validAdditionalData)
-                                  ? null
-                                  : () {
-                                      HapticFeedback.selectionClick();
-                                      setState(() {
-                                        gettingAppInfo = true;
-                                      });
-                                      sourceProvider
-                                          .getApp(pickedSource!, userInput,
-                                              additionalData,
-                                              customName: customName)
-                                          .then((app) {
-                                        var appsProvider =
-                                            context.read<AppsProvider>();
-                                        var settingsProvider =
-                                            context.read<SettingsProvider>();
-                                        if (appsProvider.apps
-                                            .containsKey(app.id)) {
-                                          throw 'App already added';
-                                        }
-                                        settingsProvider
-                                            .getInstallPermission()
-                                            .then((_) {
-                                          appsProvider
-                                              .saveApps([app]).then((_) {
+                          gettingAppInfo
+                              ? const CircularProgressIndicator()
+                              : ElevatedButton(
+                                  onPressed: gettingAppInfo ||
+                                          pickedSource == null ||
+                                          (pickedSource!.additionalDataFormItems
+                                                  .isNotEmpty &&
+                                              !validAdditionalData)
+                                      ? null
+                                      : () async {
+                                          setState(() {
+                                            gettingAppInfo = true;
+                                          });
+                                          var appsProvider =
+                                              context.read<AppsProvider>();
+                                          var settingsProvider =
+                                              context.read<SettingsProvider>();
+                                          () async {
+                                            HapticFeedback.selectionClick();
+                                            App app =
+                                                await sourceProvider.getApp(
+                                                    pickedSource!,
+                                                    userInput,
+                                                    additionalData,
+                                                    customName: customName);
+                                            await settingsProvider
+                                                .getInstallPermission();
+                                            // ignore: use_build_context_synchronously
+                                            var apkUrl = await appsProvider
+                                                .selectApkUrl(app, context);
+                                            if (apkUrl == null) {
+                                              throw 'Cancelled';
+                                            }
+                                            app.preferredApkIndex =
+                                                app.apkUrls.indexOf(apkUrl);
+                                            var downloadedApk =
+                                                await appsProvider
+                                                    .downloadApp(app);
+                                            app.id = downloadedApk.appId;
+                                            if (appsProvider.apps
+                                                .containsKey(app.id)) {
+                                              throw 'App already added';
+                                            }
+                                            await appsProvider.saveApps([app]);
+
+                                            return app;
+                                          }()
+                                              .then((app) {
                                             Navigator.push(
                                                 context,
                                                 MaterialPageRoute(
                                                     builder: (context) =>
                                                         AppPage(
                                                             appId: app.id)));
+                                          }).catchError((e) {
+                                            ScaffoldMessenger.of(context)
+                                                .showSnackBar(
+                                              SnackBar(
+                                                  content: Text(e.toString())),
+                                            );
+                                          }).whenComplete(() {
+                                            setState(() {
+                                              gettingAppInfo = false;
+                                            });
                                           });
-                                        });
-                                      }).catchError((e) {
-                                        ScaffoldMessenger.of(context)
-                                            .showSnackBar(
-                                          SnackBar(content: Text(e.toString())),
-                                        );
-                                      }).whenComplete(() {
-                                        setState(() {
-                                          gettingAppInfo = false;
-                                        });
-                                      });
-                                    },
-                              child: const Text('Add'))
+                                        },
+                                  child: const Text('Add'))
                         ],
                       ),
                       if (pickedSource != null)

--- a/lib/pages/app.dart
+++ b/lib/pages/app.dart
@@ -56,12 +56,12 @@ class _AppPageState extends State<AppPage> {
                       mainAxisAlignment: MainAxisAlignment.center,
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
-                        app?.icon != null
+                        app?.installedInfo != null
                             ? Row(
                                 mainAxisAlignment: MainAxisAlignment.center,
                                 children: [
                                     Image.memory(
-                                      app!.icon!,
+                                      app!.installedInfo!.icon!,
                                       scale: 1.5,
                                     )
                                   ])
@@ -136,7 +136,8 @@ class _AppPageState extends State<AppPage> {
                   child: Row(
                       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                       children: [
-                        if (app?.app.installedVersion != app?.app.latestVersion)
+                        if (app?.app.installedVersion != null &&
+                            app?.app.installedVersion != app?.app.latestVersion)
                           IconButton(
                               onPressed: app?.downloadProgress != null
                                   ? null
@@ -145,8 +146,8 @@ class _AppPageState extends State<AppPage> {
                                           context: context,
                                           builder: (BuildContext ctx) {
                                             return AlertDialog(
-                                              title: Text(
-                                                  'App Already ${app?.app.installedVersion == null ? 'Installed' : 'Updated'}?'),
+                                              title: const Text(
+                                                  'App Already up to Date?'),
                                               actions: [
                                                 TextButton(
                                                     onPressed: () {
@@ -171,54 +172,13 @@ class _AppPageState extends State<AppPage> {
                                                           .pop();
                                                     },
                                                     child: const Text(
-                                                        'Yes, Mark as Installed'))
+                                                        'Yes, Mark as Updated'))
                                               ],
                                             );
                                           });
                                     },
-                              tooltip: 'Mark as Installed',
-                              icon: const Icon(Icons.done))
-                        else
-                          IconButton(
-                              onPressed: app?.downloadProgress != null
-                                  ? null
-                                  : () {
-                                      showDialog(
-                                          context: context,
-                                          builder: (BuildContext ctx) {
-                                            return AlertDialog(
-                                              title: const Text(
-                                                  'App Not Installed?'),
-                                              actions: [
-                                                TextButton(
-                                                    onPressed: () {
-                                                      Navigator.of(context)
-                                                          .pop();
-                                                    },
-                                                    child: const Text('No')),
-                                                TextButton(
-                                                    onPressed: () {
-                                                      HapticFeedback
-                                                          .selectionClick();
-                                                      var updatedApp = app?.app;
-                                                      if (updatedApp != null) {
-                                                        updatedApp
-                                                                .installedVersion =
-                                                            null;
-                                                        appsProvider.saveApps(
-                                                            [updatedApp]);
-                                                      }
-                                                      Navigator.of(context)
-                                                          .pop();
-                                                    },
-                                                    child: const Text(
-                                                        'Yes, Mark as Not Installed'))
-                                              ],
-                                            );
-                                          });
-                                    },
-                              tooltip: 'Mark as Not Installed',
-                              icon: const Icon(Icons.no_cell_outlined)),
+                              tooltip: 'Mark as Updated',
+                              icon: const Icon(Icons.done)),
                         if (source != null &&
                             source.additionalDataFormItems.isNotEmpty)
                           IconButton(

--- a/lib/pages/apps.dart
+++ b/lib/pages/apps.dart
@@ -166,8 +166,8 @@ class AppsPageState extends State<AppsPage> {
                 onLongPress: () {
                   toggleAppSelected(sortedApps[index].app.id);
                 },
-                leading: sortedApps[index].icon != null
-                    ? Image.memory(sortedApps[index].icon!)
+                leading: sortedApps[index].installedInfo != null
+                    ? Image.memory(sortedApps[index].installedInfo!.icon!)
                     : null,
                 title: Text(sortedApps[index].app.name),
                 subtitle: Text('By ${sortedApps[index].app.author}'),
@@ -358,7 +358,7 @@ class AppsPageState extends State<AppsPage> {
                                     padding: const EdgeInsets.only(top: 6),
                                     child: Row(
                                         mainAxisAlignment:
-                                            MainAxisAlignment.spaceBetween,
+                                            MainAxisAlignment.spaceAround,
                                         children: [
                                           IconButton(
                                               onPressed:
@@ -373,7 +373,10 @@ class AppsPageState extends State<AppsPage> {
                                                                       ctx) {
                                                                 return AlertDialog(
                                                                   title: Text(
-                                                                      'Mark ${selectedIds.length} Selected Apps as Not Installed?'),
+                                                                      'Mark ${selectedIds.length} Selected Apps as Updated?'),
+                                                                  content:
+                                                                      const Text(
+                                                                          'Only applies to installed but out of date Apps.'),
                                                                   actions: [
                                                                     TextButton(
                                                                         onPressed:
@@ -392,8 +395,10 @@ class AppsPageState extends State<AppsPage> {
                                                                               .saveApps(selectedIds.map((e) {
                                                                             var a =
                                                                                 appsProvider.apps[e]!.app;
-                                                                            a.installedVersion =
-                                                                                null;
+                                                                            if (a.installedVersion !=
+                                                                                null) {
+                                                                              a.installedVersion = a.latestVersion;
+                                                                            }
                                                                             return a;
                                                                           }).toList());
 
@@ -407,57 +412,7 @@ class AppsPageState extends State<AppsPage> {
                                                               });
                                                         },
                                               tooltip:
-                                                  'Mark Selected Apps as Not Installed',
-                                              icon: const Icon(
-                                                  Icons.no_cell_outlined)),
-                                          IconButton(
-                                              onPressed:
-                                                  appsProvider
-                                                          .areDownloadsRunning()
-                                                      ? null
-                                                      : () {
-                                                          showDialog(
-                                                              context: context,
-                                                              builder:
-                                                                  (BuildContext
-                                                                      ctx) {
-                                                                return AlertDialog(
-                                                                  title: Text(
-                                                                      'Mark ${selectedIds.length} Selected Apps as Installed/Updated?'),
-                                                                  actions: [
-                                                                    TextButton(
-                                                                        onPressed:
-                                                                            () {
-                                                                          Navigator.of(context)
-                                                                              .pop();
-                                                                        },
-                                                                        child: const Text(
-                                                                            'No')),
-                                                                    TextButton(
-                                                                        onPressed:
-                                                                            () {
-                                                                          HapticFeedback
-                                                                              .selectionClick();
-                                                                          appsProvider
-                                                                              .saveApps(selectedIds.map((e) {
-                                                                            var a =
-                                                                                appsProvider.apps[e]!.app;
-                                                                            a.installedVersion =
-                                                                                a.latestVersion;
-                                                                            return a;
-                                                                          }).toList());
-
-                                                                          Navigator.of(context)
-                                                                              .pop();
-                                                                        },
-                                                                        child: const Text(
-                                                                            'Yes'))
-                                                                  ],
-                                                                );
-                                                              });
-                                                        },
-                                              tooltip:
-                                                  'Mark Selected Apps as Installed/Updated',
+                                                  'Mark Selected Apps as Updated',
                                               icon: const Icon(Icons.done)),
                                           IconButton(
                                             onPressed: () {

--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -56,11 +56,11 @@ class AppsProvider with ChangeNotifier {
       isForeground = event == FGBGType.foreground;
       if (isForeground) await loadApps();
     });
-    if (shouldDeleteAPKs) {
-      deleteSavedAPKs();
-    }
     if (shouldLoadApps) {
       loadApps().then((_) {
+        if (shouldDeleteAPKs) {
+          deleteSavedAPKs();
+        }
         if (shouldCheckUpdatesAfterLoad) {
           checkUpdates();
         }
@@ -68,38 +68,84 @@ class AppsProvider with ChangeNotifier {
     }
   }
 
-  Future<ApkFile> downloadApp(String apkUrl, String appId) async {
-    apkUrl = await SourceProvider()
-        .getSource(apps[appId]!.app.url)
-        .apkUrlPrefetchModifier(apkUrl);
+  downloadApk(String apkUrl, String fileName, Function? onProgress,
+      Function? urlModifier,
+      {bool useExistingIfExists = true}) async {
+    var destDir = (await getExternalStorageDirectory())!.path;
+    if (urlModifier != null) {
+      apkUrl = await urlModifier(apkUrl);
+    }
     StreamedResponse response =
         await Client().send(Request('GET', Uri.parse(apkUrl)));
-    File downloadFile =
-        File('${(await getExternalStorageDirectory())!.path}/$appId.apk');
-    if (downloadFile.existsSync()) {
-      downloadFile.deleteSync();
-    }
-    var length = response.contentLength;
-    var received = 0;
-    var sink = downloadFile.openWrite();
+    File downloadFile = File('$destDir/$fileName.apk');
+    var alreadyExists = downloadFile.existsSync();
+    if (!alreadyExists || !useExistingIfExists) {
+      if (alreadyExists) {
+        downloadFile.deleteSync();
+      }
 
-    await response.stream.map((s) {
-      received += s.length;
-      apps[appId]!.downloadProgress =
-          (length != null ? received / length * 100 : 30);
+      var length = response.contentLength;
+      var received = 0;
+      double? progress;
+      var sink = downloadFile.openWrite();
+
+      await response.stream.map((s) {
+        received += s.length;
+        progress = (length != null ? received / length * 100 : 30);
+        if (onProgress != null) {
+          onProgress(progress);
+        }
+        return s;
+      }).pipe(sink);
+
+      await sink.close();
+      progress = null;
+      if (onProgress != null) {
+        onProgress(progress);
+      }
+
+      if (response.statusCode != 200) {
+        downloadFile.deleteSync();
+        throw response.reasonPhrase ?? 'Unknown Error';
+      }
+    }
+    return downloadFile;
+  }
+
+  // Downloads the App (preferred URL) and returns an ApkFile object
+  // If the app was already saved, updates it's download progress % in memory
+  // But also works for Apps that are not saved
+  Future<ApkFile> downloadApp(App app) async {
+    var fileName = '${app.id}-${app.latestVersion}-${app.preferredApkIndex}';
+    File downloadFile = await downloadApk(app.apkUrls[app.preferredApkIndex],
+        '${app.id}-${app.latestVersion}-${app.preferredApkIndex}',
+        (double? progress) {
+      if (apps[app.id] != null) {
+        apps[app.id]!.downloadProgress = progress;
+      }
       notifyListeners();
-      return s;
-    }).pipe(sink);
-
-    await sink.close();
-    apps[appId]!.downloadProgress = null;
-    notifyListeners();
-
-    if (response.statusCode != 200) {
-      downloadFile.deleteSync();
-      throw response.reasonPhrase ?? 'Unknown Error';
+    }, SourceProvider().getSource(app.url).apkUrlPrefetchModifier);
+    // Delete older versions of the APK if any
+    for (var file in downloadFile.parent.listSync()) {
+      var fn = file.path.split('/').last;
+      if (fn.startsWith('${app.id}-') &&
+          fn.endsWith('.apk') &&
+          fn != '$fileName.apk') {
+        file.delete();
+      }
     }
-    return ApkFile(appId, downloadFile);
+    // If the ID has changed (as it should on first download), replace it
+    var newInfo = await PackageArchiveInfo.fromPath(downloadFile.path);
+    if (app.id != newInfo.packageName) {
+      app.id = newInfo.packageName;
+      downloadFile = downloadFile.renameSync(
+          '${downloadFile.parent.path}/${app.id}-${app.latestVersion}-${app.preferredApkIndex}.apk');
+      if (apps[app.id] != null) {
+        await removeApps([app.id]);
+        await saveApps([app]);
+      }
+    }
+    return ApkFile(app.id, downloadFile);
   }
 
   bool areDownloadsRunning() => apps.values
@@ -152,14 +198,34 @@ class AppsProvider with ChangeNotifier {
     }
     apps[file.appId]!.app.installedVersion =
         apps[file.appId]!.app.latestVersion;
-    if (apps[file.appId]!.app.id != newInfo.packageName) {
-      App app = apps[file.appId]!.app;
-      app.id = newInfo.packageName;
-      await removeApps([file.appId]);
-      await saveApps([app]);
-    } else {
-      await saveApps([apps[file.appId]!.app]);
+    await saveApps([apps[file.appId]!.app]);
+  }
+
+  Future<String?> selectApkUrl(App app, BuildContext? context) async {
+    // If the App has more than one APK, the user should pick one (if context provided)
+    String? apkUrl = app.apkUrls[app.preferredApkIndex];
+    if (app.apkUrls.length > 1 && context != null) {
+      apkUrl = await showDialog(
+          context: context,
+          builder: (BuildContext ctx) {
+            return APKPicker(app: app, initVal: apkUrl);
+          });
     }
+    // If the picked APK comes from an origin different from the source, get user confirmation (if context provided)
+    if (apkUrl != null &&
+        Uri.parse(apkUrl).origin != Uri.parse(app.url).origin &&
+        context != null) {
+      if (await showDialog(
+              context: context,
+              builder: (BuildContext ctx) {
+                return APKOriginWarningDialog(
+                    sourceUrl: app.url, apkUrl: apkUrl!);
+              }) !=
+          true) {
+        apkUrl = null;
+      }
+    }
+    return apkUrl;
   }
 
   // Given a list of AppIds, uses stored info about the apps to download APKs and install them
@@ -169,35 +235,14 @@ class AppsProvider with ChangeNotifier {
   // Returns an array of Ids for Apps that were successfully downloaded, regardless of installation result
   Future<List<String>> downloadAndInstallLatestApps(
       List<String> appIds, BuildContext? context) async {
-    Map<String, String> appsToInstall = {};
+    List<String> appsToInstall = [];
     for (var id in appIds) {
       if (apps[id] == null) {
         throw 'App not found';
       }
 
-      // If the App has more than one APK, the user should pick one (if context provided)
-      String? apkUrl = apps[id]!.app.apkUrls[apps[id]!.app.preferredApkIndex];
-      if (apps[id]!.app.apkUrls.length > 1 && context != null) {
-        apkUrl = await showDialog(
-            context: context,
-            builder: (BuildContext ctx) {
-              return APKPicker(app: apps[id]!.app, initVal: apkUrl);
-            });
-      }
-      // If the picked APK comes from an origin different from the source, get user confirmation (if context provided)
-      if (apkUrl != null &&
-          Uri.parse(apkUrl).origin != Uri.parse(apps[id]!.app.url).origin &&
-          context != null) {
-        if (await showDialog(
-                context: context,
-                builder: (BuildContext ctx) {
-                  return APKOriginWarningDialog(
-                      sourceUrl: apps[id]!.app.url, apkUrl: apkUrl!);
-                }) !=
-            true) {
-          apkUrl = null;
-        }
-      }
+      String? apkUrl = await selectApkUrl(apps[id]!.app, context);
+
       if (apkUrl != null) {
         int urlInd = apps[id]!.app.apkUrls.indexOf(apkUrl);
         if (urlInd != apps[id]!.app.preferredApkIndex) {
@@ -207,13 +252,13 @@ class AppsProvider with ChangeNotifier {
         if (context != null ||
             (await canInstallSilently(apps[id]!.app) &&
                 apps[id]!.app.apkUrls.length == 1)) {
-          appsToInstall.putIfAbsent(id, () => apkUrl!);
+          appsToInstall.add(id);
         }
       }
     }
 
-    List<ApkFile> downloadedFiles = await Future.wait(appsToInstall.entries
-        .map((entry) => downloadApp(entry.value, entry.key)));
+    List<ApkFile> downloadedFiles = await Future.wait(
+        appsToInstall.map((id) => downloadApp(apps[id]!.app)));
 
     List<ApkFile> silentUpdates = [];
     List<ApkFile> regularInstalls = [];
@@ -276,13 +321,38 @@ class AppsProvider with ChangeNotifier {
     return appsDir;
   }
 
+  // Delete all stored APKs except those likely to still be needed
   Future<void> deleteSavedAPKs() async {
-    (await getExternalStorageDirectory())
+    List<FileSystemEntity>? apks = (await getExternalStorageDirectory())
         ?.listSync()
         .where((element) => element.path.endsWith('.apk'))
-        .forEach((element) {
-      element.deleteSync();
-    });
+        .toList();
+    if (apks != null && apks.isNotEmpty) {
+      for (var apk in apks) {
+        var shouldDelete = true;
+        var temp = apk.path.split('/').last;
+        temp = temp.substring(0, temp.length - 4);
+        var fn = temp.split('-');
+        if (fn.length == 3) {
+          var possibleId = fn[0];
+          var possibleVersion = fn[1];
+          var possibleApkUrlIndex = fn[2];
+          if (apps[possibleId] != null) {
+            if (apps[possibleId] != null &&
+                apps[possibleId]?.app != null &&
+                apps[possibleId]!.app.installedVersion !=
+                    apps[possibleId]!.app.latestVersion &&
+                apps[possibleId]!.app.latestVersion == possibleVersion &&
+                apps[possibleId]!.app.preferredApkIndex.toString() ==
+                    possibleApkUrlIndex) {
+              shouldDelete = false;
+            }
+          }
+        }
+
+        if (shouldDelete) apk.delete();
+      }
+    }
   }
 
   Future<AppInfo?> getInstalledInfo(String? packageName) async {
@@ -294,6 +364,19 @@ class AppsProvider with ChangeNotifier {
       }
     }
     return null;
+  }
+
+  App? correctInstallStatus(App app, AppInfo? installedInfo) {
+    var modded = false;
+    if (installedInfo == null && app.installedVersion != null) {
+      app.installedVersion = null;
+      modded = true;
+    }
+    if (installedInfo != null && app.installedVersion == null) {
+      app.installedVersion = installedInfo.versionName;
+      modded = true;
+    }
+    return modded ? app : null;
   }
 
   Future<void> loadApps() async {
@@ -315,13 +398,9 @@ class AppsProvider with ChangeNotifier {
     // For any that are not installed (by ID == package name), set to not installed if needed
     List<App> modifiedApps = [];
     for (var app in apps.values) {
-      if (app.installedInfo == null && app.app.installedVersion != null) {
-        app.app.installedVersion = null;
-        modifiedApps.add(app.app);
-      }
-      if (app.installedInfo != null && app.app.installedVersion == null) {
-        app.app.installedVersion = app.installedInfo!.versionName;
-        modifiedApps.add(app.app);
+      var moddedApp = correctInstallStatus(app.app, app.installedInfo);
+      if (moddedApp != null) {
+        modifiedApps.add(moddedApp);
       }
     }
     if (modifiedApps.isNotEmpty) {

--- a/lib/providers/source_provider.dart
+++ b/lib/providers/source_provider.dart
@@ -40,7 +40,6 @@ class App {
   late int preferredApkIndex;
   late List<String> additionalData;
   late DateTime? lastUpdateCheck;
-  late String? realId;
   App(
       this.id,
       this.url,
@@ -51,8 +50,7 @@ class App {
       this.apkUrls,
       this.preferredApkIndex,
       this.additionalData,
-      this.lastUpdateCheck,
-      this.realId);
+      this.lastUpdateCheck);
 
   @override
   String toString() {
@@ -77,8 +75,7 @@ class App {
           : List<String>.from(jsonDecode(json['additionalData'])),
       json['lastUpdateCheck'] == null
           ? null
-          : DateTime.fromMicrosecondsSinceEpoch(json['lastUpdateCheck']),
-      json['realId'] == null ? null : json['realId'] as String);
+          : DateTime.fromMicrosecondsSinceEpoch(json['lastUpdateCheck']));
 
   Map<String, dynamic> toJson() => {
         'id': id,
@@ -90,8 +87,7 @@ class App {
         'apkUrls': jsonEncode(apkUrls),
         'preferredApkIndex': preferredApkIndex,
         'additionalData': jsonEncode(additionalData),
-        'lastUpdateCheck': lastUpdateCheck?.microsecondsSinceEpoch,
-        'realId': realId
+        'lastUpdateCheck': lastUpdateCheck?.microsecondsSinceEpoch
       };
 }
 
@@ -193,14 +189,17 @@ class SourceProvider {
     return false;
   }
 
+  String generateTempID(AppNames names, AppSource source) =>
+      '${names.author.toLowerCase()}_${names.name.toLowerCase()}_${source.host}';
+
   Future<App> getApp(AppSource source, String url, List<String> additionalData,
-      {String customName = '', String? realId}) async {
+      {String customName = '', String? id}) async {
     String standardUrl = source.standardizeURL(preStandardizeUrl(url));
     AppNames names = source.getAppNames(standardUrl);
     APKDetails apk =
         await source.getLatestAPKDetails(standardUrl, additionalData);
     return App(
-        '${names.author.toLowerCase()}_${names.name.toLowerCase()}_${source.host}',
+        id ?? generateTempID(names, source),
         standardUrl,
         names.author[0].toUpperCase() + names.author.substring(1),
         customName.trim().isNotEmpty
@@ -211,8 +210,7 @@ class SourceProvider {
         apk.apkUrls,
         apk.apkUrls.length - 1,
         additionalData,
-        DateTime.now(),
-        realId);
+        DateTime.now());
   }
 
   /// Returns a length 2 list, where the first element is a list of Apps and

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -112,42 +112,42 @@ packages:
       name: device_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.5"
+    version: "6.0.0"
   device_info_plus_linux:
     dependency: transitive
     description:
       name: device_info_plus_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.2"
+    version: "5.0.0"
   device_info_plus_macos:
     dependency: transitive
     description:
       name: device_info_plus_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.2"
+    version: "5.0.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
       name: device_info_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "5.0.0"
   device_info_plus_web:
     dependency: transitive
     description:
       name: device_info_plus_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.2"
+    version: "5.0.0"
   device_info_plus_windows:
     dependency: transitive
     description:
       name: device_info_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.2"
+    version: "6.0.0"
   dynamic_color:
     dependency: "direct main"
     description:
@@ -182,7 +182,7 @@ packages:
       name: file_picker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.0+1"
+    version: "5.2.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -215,14 +215,14 @@ packages:
       name: flutter_local_notifications
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "12.0.0"
+    version: "12.0.2"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "2.0.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
@@ -253,7 +253,7 @@ packages:
       name: fluttertoast
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.0.9"
+    version: "8.1.1"
   html:
     dependency: "direct main"
     description:
@@ -274,14 +274,14 @@ packages:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
   image:
     dependency: transitive
     description:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.1"
   install_plugin_v2:
     dependency: "direct main"
     description:
@@ -491,7 +491,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.3"
+    version: "6.0.4"
   share_plus:
     dependency: "direct main"
     description:
@@ -505,7 +505,7 @@ packages:
       name: share_plus_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   share_plus_macos:
     dependency: transitive
     description:
@@ -547,7 +547,7 @@ packages:
       name: shared_preferences_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.13"
+    version: "2.0.14"
   shared_preferences_ios:
     dependency: transitive
     description:
@@ -748,7 +748,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   workmanager:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.5.10+31 # When changing this, update the tag in main() accordingly
+version: 0.6.0+32 # When changing this, update the tag in main() accordingly
 
 environment:
   sdk: '>=2.19.0-79.0.dev <3.0.0'
@@ -49,7 +49,7 @@ dependencies:
   url_launcher: ^6.1.5
   permission_handler: ^10.0.0
   fluttertoast: ^8.0.9
-  device_info_plus: ^5.0.5
+  device_info_plus: ^6.0.0
   file_picker: ^5.1.0
   animations: ^2.0.4
   install_plugin_v2: ^1.0.0


### PR DESCRIPTION
Obtainium now uses real package names as IDs instead of internally-generated IDs. This allows it to detect whether Apps are already installed and mark them accordingly. When an App is uninstalled, it is also automatically marked as such in Obtainium. So the mark as installed/uninstalled buttons are no longer needed. Unfortunately, the real version number of an App may be different from the version string extracted from its Source, so a "mark as updated" button is still needed and remains.

Apps with "non-real" generated Apps may still exist due to being from previous versions of Obtainium or being imported (GitHub and URL imports also use these for convenience). These are automatically upgraded to the new format when they are installed for the first time.

WARNING: Since Obtainium automatically marks Apps as "Not Installed" if their ID does not match any installed App on the device, all Apps from older versions of Obtainium will be marked as "Not Installed" in this version. They will need to be re-installed for this to be fixed. It is inconvenient but necessary for this change.

In addition, App icons are now displayed for installed Apps with "real" package name IDs. 