### PR TITLE
Adds Track-Only App Support (Addresses #119 and Sets Groundwork for #44)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .history
 .svn/
 migrate_working_dir/
+.vscode/
 
 # IntelliJ related
 *.iml

--- a/lib/app_sources/fdroid.dart
+++ b/lib/app_sources/fdroid.dart
@@ -48,9 +48,6 @@ class FDroid extends AppSource {
           .where((element) => element['versionName'] == latestVersion)
           .map((e) => '${apkUrlPrefix}_${e['versionCode']}.apk')
           .toList();
-      if (apkUrls.isEmpty) {
-        throw NoAPKError();
-      }
       return APKDetails(latestVersion, apkUrls);
     } else {
       throw NoReleasesError();

--- a/lib/app_sources/github.dart
+++ b/lib/app_sources/github.dart
@@ -155,14 +155,11 @@ class GitHub extends AppSource {
       if (targetRelease == null) {
         throw NoReleasesError();
       }
-      if ((targetRelease['apkUrls'] as List<String>).isEmpty) {
-        throw NoAPKError();
-      }
       String? version = targetRelease['tag_name'];
       if (version == null) {
         throw NoVersionError();
       }
-      return APKDetails(version, targetRelease['apkUrls']);
+      return APKDetails(version, targetRelease['apkUrls'] as List<String>);
     } else {
       rateLimitErrorCheck(res);
       throw getObtainiumHttpError(res);

--- a/lib/app_sources/github.dart
+++ b/lib/app_sources/github.dart
@@ -11,9 +11,9 @@ class GitHub extends AppSource {
   GitHub() {
     host = 'github.com';
 
-    additionalDataDefaults = ['true', 'true', ''];
+    additionalSourceAppSpecificDefaults = ['true', 'true', ''];
 
-    moreSourceSettingsFormItems = [
+    additionalSourceSpecificSettingFormItems = [
       GeneratedFormItem(
           label: 'GitHub Personal Access Token (Increases Rate Limit)',
           id: 'github-creds',
@@ -51,7 +51,7 @@ class GitHub extends AppSource {
           ])
     ];
 
-    additionalDataFormItems = [
+    additionalSourceAppSpecificFormItems = [
       [
         GeneratedFormItem(label: 'Include prereleases', type: FormItemType.bool)
       ],
@@ -96,8 +96,8 @@ class GitHub extends AppSource {
   Future<String> getCredentialPrefixIfAny() async {
     SettingsProvider settingsProvider = SettingsProvider();
     await settingsProvider.initializeSettings();
-    String? creds =
-        settingsProvider.getSettingString(moreSourceSettingsFormItems[0].id);
+    String? creds = settingsProvider
+        .getSettingString(additionalSourceSpecificSettingFormItems[0].id);
     return creds != null && creds.isNotEmpty ? '$creds@' : '';
   }
 

--- a/lib/app_sources/gitlab.dart
+++ b/lib/app_sources/gitlab.dart
@@ -33,7 +33,7 @@ class GitLab extends AppSource {
       var entry = parsedHtml.querySelector('entry');
       var entryContent =
           parse(parseFragment(entry?.querySelector('content')!.innerHtml).text);
-      var apkUrlList = [
+      var apkUrls = [
         ...getLinksFromParsedHTML(
             entryContent,
             RegExp(
@@ -48,9 +48,6 @@ class GitLab extends AppSource {
             .where((element) => Uri.parse(element).host != '')
             .toList()
       ];
-      if (apkUrlList.isEmpty) {
-        throw NoAPKError();
-      }
 
       var entryId = entry?.querySelector('id')?.innerHtml;
       var version =
@@ -58,7 +55,7 @@ class GitLab extends AppSource {
       if (version == null) {
         throw NoVersionError();
       }
-      return APKDetails(version, apkUrlList);
+      return APKDetails(version, apkUrls);
     } else {
       throw NoReleasesError();
     }

--- a/lib/app_sources/signal.dart
+++ b/lib/app_sources/signal.dart
@@ -24,14 +24,12 @@ class Signal extends AppSource {
     if (res.statusCode == 200) {
       var json = jsonDecode(res.body);
       String? apkUrl = json['url'];
-      if (apkUrl == null) {
-        throw NoAPKError();
-      }
+      List<String> apkUrls = apkUrl == null ? [] : [apkUrl];
       String? version = json['versionName'];
       if (version == null) {
         throw NoVersionError();
       }
-      return APKDetails(version, [apkUrl]);
+      return APKDetails(version, apkUrls);
     } else {
       throw NoReleasesError();
     }

--- a/lib/app_sources/sourceforge.dart
+++ b/lib/app_sources/sourceforge.dart
@@ -49,9 +49,6 @@ class SourceForge extends AppSource {
           apkUrlListAllReleases // This can be used skipped for fallback support later
               .where((element) => getVersion(element) == version)
               .toList();
-      if (apkUrlList.isEmpty) {
-        throw NoAPKError();
-      }
       return APKDetails(version, apkUrlList);
     } else {
       throw NoReleasesError();

--- a/lib/components/generated_form.dart
+++ b/lib/components/generated_form.dart
@@ -6,6 +6,7 @@ typedef OnValueChanges = void Function(
     List<String> values, bool valid, bool isBuilding);
 
 class GeneratedFormItem {
+  late String key;
   late String label;
   late FormItemType type;
   late bool required;
@@ -25,7 +26,8 @@ class GeneratedFormItem {
       this.id = 'input',
       this.belowWidgets = const [],
       this.hint,
-      this.opts});
+      this.opts,
+      this.key = 'default'});
 }
 
 class GeneratedForm extends StatefulWidget {
@@ -208,4 +210,19 @@ class _GeneratedFormState extends State<GeneratedForm> {
           ],
         ));
   }
+}
+
+String? findGeneratedFormValueByKey(
+    List<GeneratedFormItem> items, List<String> values, String key) {
+  var foundIndex = -1;
+  for (var i = 0; i < items.length; i++) {
+    if (items[i].key == key) {
+      foundIndex = i;
+      break;
+    }
+  }
+  if (foundIndex >= 0 && foundIndex < values.length) {
+    return values[foundIndex];
+  }
+  return null;
 }

--- a/lib/components/generated_form_modal.dart
+++ b/lib/components/generated_form_modal.dart
@@ -29,7 +29,7 @@ class _GeneratedFormModalState extends State<GeneratedFormModal> {
   void initState() {
     super.initState();
     values = widget.defaultValues;
-    valid = widget.initValid;
+    valid = widget.initValid || widget.items.isEmpty;
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -154,6 +154,7 @@ class _ObtainiumState extends State<Obtainium> {
               0,
               ['true'],
               null,
+              false,
               false)
         ]);
       }

--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -67,7 +67,7 @@ class _AddAppPageState extends State<AddAppPage> {
                                     ]
                                   ],
                                   onValueChanges: (values, valid, isBuilding) {
-                                    setState(() {
+                                    fn() {
                                       userInput = values[0];
                                       var source = valid
                                           ? sourceProvider.getSource(userInput)
@@ -83,7 +83,15 @@ class _AddAppPageState extends State<AddAppPage> {
                                                     source)
                                             : true;
                                       }
-                                    });
+                                    }
+
+                                    if (isBuilding) {
+                                      fn();
+                                    } else {
+                                      setState(() {
+                                        fn();
+                                      });
+                                    }
                                   },
                                   defaultValues: const [])),
                           const SizedBox(
@@ -180,10 +188,15 @@ class _AddAppPageState extends State<AddAppPage> {
                               GeneratedForm(
                                   items: pickedSource!.additionalDataFormItems,
                                   onValueChanges: (values, valid, isBuilding) {
-                                    setState(() {
+                                    if (isBuilding) {
                                       additionalData = values;
                                       validAdditionalData = valid;
-                                    });
+                                    } else {
+                                      setState(() {
+                                        additionalData = values;
+                                        validAdditionalData = valid;
+                                      });
+                                    }
                                   },
                                   defaultValues:
                                       pickedSource!.additionalDataDefaults),

--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -166,7 +166,8 @@ class _AddAppPageState extends State<AddAppPage> {
                                                   .getInstallPermission();
                                               // Only download the APK here if you need to for the package ID
                                               if (sourceProvider
-                                                  .isTempId(app.id)) {
+                                                      .isTempId(app.id) &&
+                                                  !app.trackOnly) {
                                                 // ignore: use_build_context_synchronously
                                                 var apkUrl = await appsProvider
                                                     .confirmApkUrl(
@@ -186,6 +187,10 @@ class _AddAppPageState extends State<AddAppPage> {
                                                   .containsKey(app.id)) {
                                                 throw ObtainiumError(
                                                     'App already added');
+                                              }
+                                              if (app.trackOnly) {
+                                                app.installedVersion =
+                                                    app.latestVersion;
                                               }
                                               await appsProvider
                                                   .saveApps([app]);

--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -147,7 +147,7 @@ class _AddAppPageState extends State<AddAppPage> {
                                                             items: const [],
                                                             defaultValues: const [],
                                                             message:
-                                                                '${pickedSource!.enforceTrackOnly ? 'Apps from this source are \'Track Only\'.' : 'You have selected the \'Track Only\' option.'}\n\nThe App will be tracked for updates, but Obtainium will not be able to download or install it.',
+                                                                '${pickedSource!.enforceTrackOnly ? 'Apps from this source are \'Track-Only\'.' : 'You have selected the \'Track-Only\' option.'}\n\nThe App will be tracked for updates, but Obtainium will not be able to download or install it.',
                                                           );
                                                         }) ==
                                                     null) {

--- a/lib/pages/app.dart
+++ b/lib/pages/app.dart
@@ -183,7 +183,8 @@ class _AppPageState extends State<AppPage> {
                               tooltip: 'Mark as Updated',
                               icon: const Icon(Icons.done)),
                         if (source != null &&
-                            source.additionalDataFormItems.isNotEmpty)
+                            source.additionalSourceAppSpecificFormItems
+                                .isNotEmpty)
                           IconButton(
                               onPressed: app?.downloadProgress != null
                                   ? null
@@ -194,11 +195,11 @@ class _AppPageState extends State<AppPage> {
                                             return GeneratedFormModal(
                                                 title: 'Additional Options',
                                                 items: source
-                                                    .additionalDataFormItems,
+                                                    .additionalSourceAppSpecificFormItems,
                                                 defaultValues: app != null
                                                     ? app.app.additionalData
                                                     : source
-                                                        .additionalDataDefaults);
+                                                        .additionalSourceAppSpecificDefaults);
                                           }).then((values) {
                                         if (app != null && values != null) {
                                           var changedApp = app.app;

--- a/lib/pages/app.dart
+++ b/lib/pages/app.dart
@@ -106,7 +106,7 @@ class _AppPageState extends State<AppPage> {
                           style: Theme.of(context).textTheme.bodyLarge,
                         ),
                         Text(
-                          'Installed Version: ${app?.app.installedVersion ?? 'None'}',
+                          'Installed Version: ${app?.app.installedVersion ?? 'None'}${app?.app.trackOnly == true ? ' (Estimate)\n\nApp is Track-Only' : ''}',
                           textAlign: TextAlign.center,
                           style: Theme.of(context).textTheme.bodyLarge,
                         ),
@@ -140,6 +140,7 @@ class _AppPageState extends State<AppPage> {
                       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                       children: [
                         if (app?.app.installedVersion != null &&
+                            app?.app.trackOnly == false &&
                             app?.app.installedVersion != app?.app.latestVersion)
                           IconButton(
                               onPressed: app?.downloadProgress != null
@@ -235,8 +236,12 @@ class _AppPageState extends State<AppPage> {
                                       }
                                     : null,
                                 child: Text(app?.app.installedVersion == null
-                                    ? 'Install'
-                                    : 'Update'))),
+                                    ? app?.app.trackOnly == false
+                                        ? 'Install'
+                                        : 'Mark Installed'
+                                    : app?.app.trackOnly == false
+                                        ? 'Update'
+                                        : 'Mark Updated'))),
                         const SizedBox(width: 16.0),
                         ElevatedButton(
                           onPressed: app?.downloadProgress != null

--- a/lib/pages/apps.dart
+++ b/lib/pages/apps.dart
@@ -276,8 +276,7 @@ class AppsPageState extends State<AppsPage> {
                             child: SizedBox(
                                 width: 80,
                                 child: Text(
-                                  sortedApps[index].app.installedVersion ??
-                                      'Not Installed',
+                                  '${sortedApps[index].app.installedVersion ?? 'Not Installed'} ${sortedApps[index].app.trackOnly == true ? '(Estimate)' : ''}',
                                   overflow: TextOverflow.fade,
                                   textAlign: TextAlign.end,
                                 )))),

--- a/lib/pages/apps.dart
+++ b/lib/pages/apps.dart
@@ -400,9 +400,13 @@ class AppsPageState extends State<AppsPage> {
                             showDialog<List<String>?>(
                                 context: context,
                                 builder: (BuildContext ctx) {
+                                  var totalApps = existingUpdateIdsAllOrSelected
+                                          .length +
+                                      newInstallIdsAllOrSelected.length +
+                                      trackOnlyUpdateIdsAllOrSelected.length;
                                   return GeneratedFormModal(
                                     title:
-                                        'Install ${existingUpdateIdsAllOrSelected.length + newInstallIdsAllOrSelected.length + trackOnlyUpdateIdsAllOrSelected.length} Apps?',
+                                        'Change $totalApps App${totalApps == 1 ? '' : 's'}',
                                     items: formInputs.map((e) => [e]).toList(),
                                     defaultValues: defaultValues,
                                     initValid: true,

--- a/lib/pages/import_export.dart
+++ b/lib/pages/import_export.dart
@@ -42,7 +42,7 @@ class _ImportExportPageState extends State<ImportExportPage> {
 
     Future<List<List<String>>> addApps(List<String> urls) async {
       await settingsProvider.getInstallPermission();
-      List<dynamic> results = await sourceProvider.getApps(urls,
+      List<dynamic> results = await sourceProvider.getAppsByURLNaive(urls,
           ignoreUrls: appsProvider.apps.values.map((e) => e.app.url).toList());
       List<App> apps = results[0];
       Map<String, dynamic> errorsMap = results[1];

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -139,18 +139,21 @@ class _SettingsPageState extends State<SettingsPage> {
         });
 
     var sourceSpecificFields = sourceProvider.sources.map((e) {
-      if (e.moreSourceSettingsFormItems.isNotEmpty) {
+      if (e.additionalSourceSpecificSettingFormItems.isNotEmpty) {
         return GeneratedForm(
-            items: e.moreSourceSettingsFormItems.map((e) => [e]).toList(),
+            items: e.additionalSourceSpecificSettingFormItems
+                .map((e) => [e])
+                .toList(),
             onValueChanges: (values, valid, isBuilding) {
               if (valid) {
                 for (var i = 0; i < values.length; i++) {
                   settingsProvider.setSettingString(
-                      e.moreSourceSettingsFormItems[i].id, values[i]);
+                      e.additionalSourceSpecificSettingFormItems[i].id,
+                      values[i]);
                 }
               }
             },
-            defaultValues: e.moreSourceSettingsFormItems.map((e) {
+            defaultValues: e.additionalSourceSpecificSettingFormItems.map((e) {
               return settingsProvider.getSettingString(e.id) ?? '';
             }).toList());
       } else {

--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -512,7 +512,8 @@ class AppsProvider with ChangeNotifier {
         currentApp.additionalData,
         name: currentApp.name,
         id: currentApp.id,
-        pinned: currentApp.pinned);
+        pinned: currentApp.pinned,
+        trackOnly: currentApp.trackOnly);
     newApp.installedVersion = currentApp.installedVersion;
     if (currentApp.preferredApkIndex < newApp.apkUrls.length) {
       newApp.preferredApkIndex = currentApp.preferredApkIndex;

--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -460,8 +460,7 @@ class AppsProvider with ChangeNotifier {
       var info = await getInstalledInfo(newApps[i].id);
       try {
         sp.getSource(newApps[i].url);
-        apps.putIfAbsent(
-            newApps[i].id, () => AppInMemory(newApps[i], null, info));
+        apps[newApps[i].id] = AppInMemory(newApps[i], null, info);
       } catch (e) {
         errors.add([newApps[i].id, newApps[i].name, e.toString()]);
       }

--- a/lib/providers/source_provider.dart
+++ b/lib/providers/source_provider.dart
@@ -261,11 +261,13 @@ class SourceProvider {
       {String name = '',
       String? id,
       bool pinned = false,
-      bool trackOnly = false}) async {
+      bool trackOnly = false,
+      String? installedVersion}) async {
     String standardUrl = source.standardizeURL(preStandardizeUrl(url));
     AppNames names = source.getAppNames(standardUrl);
     APKDetails apk =
         await source.getLatestAPKDetails(standardUrl, additionalData);
+    String apkVersion = apk.version.replaceAll('/', '-');
     return App(
         id ??
             source.tryInferringAppId(standardUrl) ??
@@ -275,8 +277,8 @@ class SourceProvider {
         name.trim().isNotEmpty
             ? name
             : names.name[0].toUpperCase() + names.name.substring(1),
-        null,
-        apk.version.replaceAll('/', '-'),
+        installedVersion,
+        apkVersion,
         apk.apkUrls,
         apk.apkUrls.length - 1,
         additionalData,

--- a/lib/providers/source_provider.dart
+++ b/lib/providers/source_provider.dart
@@ -162,7 +162,7 @@ class AppSource {
   // Some additional data may be needed for Apps regardless of Source
   final List<GeneratedFormItem> additionalAppSpecificSourceAgnosticFormItems = [
     GeneratedFormItem(
-        label: 'Track Only',
+        label: 'Track-Only',
         type: FormItemType.bool,
         key: 'trackOnlyFormItemKey')
   ];

--- a/lib/providers/source_provider.dart
+++ b/lib/providers/source_provider.dart
@@ -267,6 +267,9 @@ class SourceProvider {
     AppNames names = source.getAppNames(standardUrl);
     APKDetails apk =
         await source.getLatestAPKDetails(standardUrl, additionalData);
+    if (apk.apkUrls.isEmpty && !trackOnly) {
+      throw NoAPKError();
+    }
     String apkVersion = apk.version.replaceAll('/', '-');
     return App(
         id ??


### PR DESCRIPTION
- All Sources now have a "Track-Only" option that will prevent Obtainium from looking for APKs (though the App must still have a release of some kind so that a version string can be grabbed).
    - These Apps cannot be installed through Obtainium, but update notifications will still be sent.
    - The user needs to manually mark them as updated when appropriate.
    - This addresses issue #119.
    - It also partially addresses #44 by allowing some sources to be configured as "Track-Only"-only. The first such source (APKMirror) will be added later.
- Includes various UI changes to accommodate the above change.
- Also makes App loading a bit more responsive (sending Obtainium to the background then returning will now cause App re-load to pick up changes in App versioning that may have been made in the meantime, for instance through update checking).