### PR TITLE
Broke `GeneratedFormItem` into sub-types + bugfix

### DIFF
--- a/lib/app_sources/apkmirror.dart
+++ b/lib/app_sources/apkmirror.dart
@@ -26,7 +26,7 @@ class APKMirror extends AppSource {
   @override
   Future<APKDetails> getLatestAPKDetails(
     String standardUrl,
-    Map<String, String> additionalSettings,
+    Map<String, dynamic> additionalSettings,
   ) async {
     Response res = await get(Uri.parse('$standardUrl/feed'));
     if (res.statusCode == 200) {

--- a/lib/app_sources/fdroid.dart
+++ b/lib/app_sources/fdroid.dart
@@ -32,7 +32,7 @@ class FDroid extends AppSource {
 
   @override
   String? tryInferringAppId(String standardUrl,
-      {Map<String, String> additionalSettings = const {}}) {
+      {Map<String, dynamic> additionalSettings = const {}}) {
     return Uri.parse(standardUrl).pathSegments.last;
   }
 
@@ -61,7 +61,7 @@ class FDroid extends AppSource {
   @override
   Future<APKDetails> getLatestAPKDetails(
     String standardUrl,
-    Map<String, String> additionalSettings,
+    Map<String, dynamic> additionalSettings,
   ) async {
     String? appId = tryInferringAppId(standardUrl);
     return getAPKUrlsFromFDroidPackagesAPIResponse(

--- a/lib/app_sources/fdroidrepo.dart
+++ b/lib/app_sources/fdroidrepo.dart
@@ -11,7 +11,7 @@ class FDroidRepo extends AppSource {
 
     additionalSourceAppSpecificSettingFormItems = [
       [
-        GeneratedFormItem('appIdOrName',
+        GeneratedFormTextField('appIdOrName',
             label: tr('appIdOrName'),
             hint: tr('reposHaveMultipleApps'),
             required: true)
@@ -33,7 +33,7 @@ class FDroidRepo extends AppSource {
   @override
   Future<APKDetails> getLatestAPKDetails(
     String standardUrl,
-    Map<String, String> additionalSettings,
+    Map<String, dynamic> additionalSettings,
   ) async {
     String? appIdOrName = additionalSettings['appIdOrName'];
     if (appIdOrName == null) {

--- a/lib/app_sources/github.dart
+++ b/lib/app_sources/github.dart
@@ -13,7 +13,7 @@ class GitHub extends AppSource {
     host = 'github.com';
 
     additionalSourceSpecificSettingFormItems = [
-      GeneratedFormItem('github-creds',
+      GeneratedFormTextField('github-creds',
           label: tr('githubPATLabel'),
           required: false,
           additionalValidators: [
@@ -51,21 +51,16 @@ class GitHub extends AppSource {
 
     additionalSourceAppSpecificSettingFormItems = [
       [
-        GeneratedFormItem('includePrereleases',
-            label: tr('includePrereleases'),
-            type: FormItemType.bool,
-            defaultValue: '')
+        GeneratedFormSwitch('includePrereleases',
+            label: tr('includePrereleases'), defaultValue: false)
       ],
       [
-        GeneratedFormItem('fallbackToOlderReleases',
-            label: tr('fallbackToOlderReleases'),
-            type: FormItemType.bool,
-            defaultValue: 'true')
+        GeneratedFormSwitch('fallbackToOlderReleases',
+            label: tr('fallbackToOlderReleases'), defaultValue: true)
       ],
       [
-        GeneratedFormItem('filterReleaseTitlesByRegEx',
+        GeneratedFormTextField('filterReleaseTitlesByRegEx',
             label: tr('filterReleaseTitlesByRegEx'),
-            type: FormItemType.string,
             required: false,
             additionalValidators: [
               (value) {
@@ -111,13 +106,15 @@ class GitHub extends AppSource {
   @override
   Future<APKDetails> getLatestAPKDetails(
     String standardUrl,
-    Map<String, String> additionalSettings,
+    Map<String, dynamic> additionalSettings,
   ) async {
-    var includePrereleases = additionalSettings['includePrereleases'] == 'true';
-    var fallbackToOlderReleases =
-        additionalSettings['fallbackToOlderReleases'] == 'true';
-    var regexFilter =
-        additionalSettings['filterReleaseTitlesByRegEx']?.isNotEmpty == true
+    bool includePrereleases = additionalSettings['includePrereleases'];
+    bool fallbackToOlderReleases =
+        additionalSettings['fallbackToOlderReleases'];
+    String? regexFilter =
+        (additionalSettings['filterReleaseTitlesByRegEx'] as String?)
+                    ?.isNotEmpty ==
+                true
             ? additionalSettings['filterReleaseTitlesByRegEx']
             : null;
     Response res = await get(Uri.parse(
@@ -150,7 +147,7 @@ class GitHub extends AppSource {
           continue;
         }
         var apkUrls = getReleaseAPKUrls(releases[i]);
-        if (apkUrls.isEmpty && additionalSettings['trackOnly'] != 'true') {
+        if (apkUrls.isEmpty && additionalSettings['trackOnly'] != true) {
           continue;
         }
         targetRelease = releases[i];

--- a/lib/app_sources/gitlab.dart
+++ b/lib/app_sources/gitlab.dart
@@ -26,7 +26,7 @@ class GitLab extends AppSource {
   @override
   Future<APKDetails> getLatestAPKDetails(
     String standardUrl,
-    Map<String, String> additionalSettings,
+    Map<String, dynamic> additionalSettings,
   ) async {
     Response res = await get(Uri.parse('$standardUrl/-/tags?format=atom'));
     if (res.statusCode == 200) {

--- a/lib/app_sources/izzyondroid.dart
+++ b/lib/app_sources/izzyondroid.dart
@@ -23,14 +23,14 @@ class IzzyOnDroid extends AppSource {
 
   @override
   String? tryInferringAppId(String standardUrl,
-      {Map<String, String> additionalSettings = const {}}) {
+      {Map<String, dynamic> additionalSettings = const {}}) {
     return FDroid().tryInferringAppId(standardUrl);
   }
 
   @override
   Future<APKDetails> getLatestAPKDetails(
     String standardUrl,
-    Map<String, String> additionalSettings,
+    Map<String, dynamic> additionalSettings,
   ) async {
     String? appId = tryInferringAppId(standardUrl);
     return FDroid().getAPKUrlsFromFDroidPackagesAPIResponse(

--- a/lib/app_sources/mullvad.dart
+++ b/lib/app_sources/mullvad.dart
@@ -25,7 +25,7 @@ class Mullvad extends AppSource {
   @override
   Future<APKDetails> getLatestAPKDetails(
     String standardUrl,
-    Map<String, String> additionalSettings,
+    Map<String, dynamic> additionalSettings,
   ) async {
     Response res = await get(Uri.parse('$standardUrl/en/download/android'));
     if (res.statusCode == 200) {

--- a/lib/app_sources/signal.dart
+++ b/lib/app_sources/signal.dart
@@ -19,7 +19,7 @@ class Signal extends AppSource {
   @override
   Future<APKDetails> getLatestAPKDetails(
     String standardUrl,
-    Map<String, String> additionalSettings,
+    Map<String, dynamic> additionalSettings,
   ) async {
     Response res =
         await get(Uri.parse('https://updates.$host/android/latest.json'));

--- a/lib/app_sources/sourceforge.dart
+++ b/lib/app_sources/sourceforge.dart
@@ -24,7 +24,7 @@ class SourceForge extends AppSource {
   @override
   Future<APKDetails> getLatestAPKDetails(
     String standardUrl,
-    Map<String, String> additionalSettings,
+    Map<String, dynamic> additionalSettings,
   ) async {
     Response res = await get(Uri.parse('$standardUrl/rss?path=/'));
     if (res.statusCode == 200) {

--- a/lib/app_sources/steammobile.dart
+++ b/lib/app_sources/steammobile.dart
@@ -10,10 +10,7 @@ class SteamMobile extends AppSource {
     host = 'store.steampowered.com';
     name = tr('steam');
     additionalSourceAppSpecificSettingFormItems = [
-      [
-        GeneratedFormItem('app',
-            label: tr('app'), required: true, opts: apks.entries.toList())
-      ]
+      [GeneratedFormDropdown('app', apks.entries.toList(), label: tr('app'))]
     ];
   }
 
@@ -30,11 +27,11 @@ class SteamMobile extends AppSource {
   @override
   Future<APKDetails> getLatestAPKDetails(
     String standardUrl,
-    Map<String, String> additionalSettings,
+    Map<String, dynamic> additionalSettings,
   ) async {
     Response res = await get(Uri.parse('https://$host/mobile'));
     if (res.statusCode == 200) {
-      var apkNamePrefix = additionalSettings['app'];
+      var apkNamePrefix = additionalSettings['app'] as String?;
       if (apkNamePrefix == null) {
         throw NoReleasesError();
       }

--- a/lib/components/generated_form_modal.dart
+++ b/lib/components/generated_form_modal.dart
@@ -21,7 +21,7 @@ class GeneratedFormModal extends StatefulWidget {
 }
 
 class _GeneratedFormModalState extends State<GeneratedFormModal> {
-  Map<String, String> values = {};
+  Map<String, dynamic> values = {};
   bool valid = false;
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -200,7 +200,7 @@ class _ObtainiumState extends State<Obtainium> {
               currentReleaseTag,
               [],
               0,
-              {'includePrereleases': 'true'},
+              {'includePrereleases': true},
               null,
               false)
         ]);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,7 +21,7 @@ import 'package:easy_localization/src/easy_localization_controller.dart';
 // ignore: implementation_imports
 import 'package:easy_localization/src/localization.dart';
 
-const String currentVersion = '0.9.1';
+const String currentVersion = '0.9.2';
 const String currentReleaseTag =
     'v$currentVersion-beta'; // KEEP THIS IN SYNC WITH GITHUB RELEASES
 

--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -27,7 +27,7 @@ class _AddAppPageState extends State<AddAppPage> {
   String userInput = '';
   String searchQuery = '';
   AppSource? pickedSource;
-  Map<String, String> additionalSettings = {};
+  Map<String, dynamic> additionalSettings = {};
   bool additionalSettingsValid = true;
 
   @override
@@ -66,9 +66,9 @@ class _AddAppPageState extends State<AddAppPage> {
       });
       var settingsProvider = context.read<SettingsProvider>();
       () async {
-        var userPickedTrackOnly = additionalSettings['trackOnly'] == 'true';
+        var userPickedTrackOnly = additionalSettings['trackOnly'] == true;
         var userPickedNoVersionDetection =
-            additionalSettings['noVersionDetection'] == 'true';
+            additionalSettings['noVersionDetection'] == true;
         var cont = true;
         if ((userPickedTrackOnly || pickedSource!.enforceTrackOnly) &&
             await showDialog(
@@ -113,7 +113,7 @@ class _AddAppPageState extends State<AddAppPage> {
           }
           // Only download the APK here if you need to for the package ID
           if (sourceProvider.isTempId(app.id) &&
-              app.additionalSettings['trackOnly'] != 'true') {
+              app.additionalSettings['trackOnly'] != true) {
             // ignore: use_build_context_synchronously
             var apkUrl = await appsProvider.confirmApkUrl(app, context);
             if (apkUrl == null) {
@@ -128,7 +128,7 @@ class _AddAppPageState extends State<AddAppPage> {
           if (appsProvider.apps.containsKey(app.id)) {
             throw ObtainiumError(tr('appAlreadyAdded'));
           }
-          if (app.additionalSettings['trackOnly'] == 'true') {
+          if (app.additionalSettings['trackOnly'] == true) {
             app.installedVersion = app.latestVersion;
           }
           await appsProvider.saveApps([app]);
@@ -169,7 +169,7 @@ class _AddAppPageState extends State<AddAppPage> {
                               child: GeneratedForm(
                                   items: [
                                 [
-                                  GeneratedFormItem('appSourceURL',
+                                  GeneratedFormTextField('appSourceURL',
                                       label: tr('appSourceURL'),
                                       additionalValidators: [
                                         (value) {
@@ -231,7 +231,8 @@ class _AddAppPageState extends State<AddAppPage> {
                               child: GeneratedForm(
                                   items: [
                                     [
-                                      GeneratedFormItem('searchSomeSources',
+                                      GeneratedFormTextField(
+                                          'searchSomeSources',
                                           label: tr('searchSomeSourcesLabel'),
                                           required: false),
                                     ]

--- a/lib/pages/app.dart
+++ b/lib/pages/app.dart
@@ -42,7 +42,7 @@ class _AppPageState extends State<AppPage> {
       prevApp = app;
       getUpdate(app.app.id);
     }
-    var trackOnly = app?.app.additionalSettings['trackOnly'] == 'true';
+    var trackOnly = app?.app.additionalSettings['trackOnly'] == true;
     return Scaffold(
       appBar: settingsProvider.showAppWebpage ? AppBar() : null,
       backgroundColor: Theme.of(context).colorScheme.surface,
@@ -170,7 +170,7 @@ class _AppPageState extends State<AppPage> {
                                 children: [
                                     TextButton(
                                         onPressed: () {
-                                          showDialog<Map<String, String>?>(
+                                          showDialog<Map<String, dynamic>?>(
                                               context: context,
                                               builder: (BuildContext ctx) {
                                                 return GeneratedFormModal(
@@ -273,7 +273,7 @@ class _AppPageState extends State<AppPage> {
                               onPressed: app?.downloadProgress != null
                                   ? null
                                   : () {
-                                      showDialog<Map<String, String>>(
+                                      showDialog<Map<String, dynamic>?>(
                                           context: context,
                                           builder: (BuildContext ctx) {
                                             var items = source
@@ -301,7 +301,7 @@ class _AppPageState extends State<AppPage> {
                                               values;
                                           if (source.enforceTrackOnly) {
                                             changedApp.additionalSettings[
-                                                'trackOnly'] = 'true';
+                                                'trackOnly'] = true;
                                             showError(
                                                 tr('appsFromSourceAreTrackOnly'),
                                                 context);
@@ -327,7 +327,7 @@ class _AppPageState extends State<AppPage> {
                                         () async {
                                           if (app?.app.additionalSettings[
                                                   'trackOnly'] !=
-                                              'true') {
+                                              true) {
                                             await settingsProvider
                                                 .getInstallPermission();
                                           }

--- a/lib/pages/apps.dart
+++ b/lib/pages/apps.dart
@@ -142,16 +142,14 @@ class AppsPageState extends State<AppsPage> {
 
     List<String> trackOnlyUpdateIdsAllOrSelected = [];
     existingUpdateIdsAllOrSelected = existingUpdateIdsAllOrSelected.where((id) {
-      if (appsProvider.apps[id]!.app.additionalSettings['trackOnly'] ==
-          'true') {
+      if (appsProvider.apps[id]!.app.additionalSettings['trackOnly'] == true) {
         trackOnlyUpdateIdsAllOrSelected.add(id);
         return false;
       }
       return true;
     }).toList();
     newInstallIdsAllOrSelected = newInstallIdsAllOrSelected.where((id) {
-      if (appsProvider.apps[id]!.app.additionalSettings['trackOnly'] ==
-          'true') {
+      if (appsProvider.apps[id]!.app.additionalSettings['trackOnly'] == true) {
         trackOnlyUpdateIdsAllOrSelected.add(id);
         return false;
       }
@@ -286,7 +284,7 @@ class AppsPageState extends State<AppsPage> {
                                   SizedBox(
                                       width: 100,
                                       child: Text(
-                                        '${sortedApps[index].app.installedVersion ?? tr('notInstalled')}${sortedApps[index].app.additionalSettings['trackOnly'] == 'true' ? ' ${tr('estimateInBrackets')}' : ''}',
+                                        '${sortedApps[index].app.installedVersion ?? tr('notInstalled')}${sortedApps[index].app.additionalSettings['trackOnly'] == true ? ' ${tr('estimateInBrackets')}' : ''}',
                                         overflow: TextOverflow.fade,
                                         textAlign: TextAlign.end,
                                       )),
@@ -310,7 +308,7 @@ class AppsPageState extends State<AppsPage> {
                                                   .areDownloadsRunning()
                                               ? Text(tr('pleaseWait'))
                                               : Text(
-                                                  '${tr('updateAvailable')}${sortedApps[index].app.additionalSettings['trackOnly'] == 'true' ? ' ${tr('estimateInBracketsShort')}' : ''}',
+                                                  '${tr('updateAvailable')}${sortedApps[index].app.additionalSettings['trackOnly'] == true ? ' ${tr('estimateInBracketsShort')}' : ''}',
                                                   style: TextStyle(
                                                       fontStyle:
                                                           FontStyle.italic,
@@ -366,7 +364,7 @@ class AppsPageState extends State<AppsPage> {
                     : IconButton(
                         visualDensity: VisualDensity.compact,
                         onPressed: () {
-                          showDialog<Map<String, String>?>(
+                          showDialog<Map<String, dynamic>?>(
                               context: context,
                               builder: (BuildContext ctx) {
                                 return GeneratedFormModal(
@@ -400,40 +398,33 @@ class AppsPageState extends State<AppsPage> {
                             HapticFeedback.heavyImpact();
                             List<GeneratedFormItem> formItems = [];
                             if (existingUpdateIdsAllOrSelected.isNotEmpty) {
-                              formItems.add(GeneratedFormItem('updates',
+                              formItems.add(GeneratedFormSwitch('updates',
                                   label: tr('updateX', args: [
                                     plural('apps',
                                         existingUpdateIdsAllOrSelected.length)
                                   ]),
-                                  type: FormItemType.bool,
-                                  defaultValue: 'true'));
+                                  defaultValue: true));
                             }
                             if (newInstallIdsAllOrSelected.isNotEmpty) {
-                              formItems.add(GeneratedFormItem('installs',
+                              formItems.add(GeneratedFormSwitch('installs',
                                   label: tr('installX', args: [
                                     plural('apps',
                                         newInstallIdsAllOrSelected.length)
                                   ]),
-                                  type: FormItemType.bool,
-                                  defaultValue:
-                                      existingUpdateIdsAllOrSelected.isNotEmpty
-                                          ? 'true'
-                                          : ''));
+                                  defaultValue: existingUpdateIdsAllOrSelected
+                                      .isNotEmpty));
                             }
                             if (trackOnlyUpdateIdsAllOrSelected.isNotEmpty) {
-                              formItems.add(GeneratedFormItem('trackonlies',
+                              formItems.add(GeneratedFormSwitch('trackonlies',
                                   label: tr('markXTrackOnlyAsUpdated', args: [
                                     plural('apps',
                                         trackOnlyUpdateIdsAllOrSelected.length)
                                   ]),
-                                  type: FormItemType.bool,
                                   defaultValue: existingUpdateIdsAllOrSelected
-                                              .isNotEmpty ||
-                                          newInstallIdsAllOrSelected.isNotEmpty
-                                      ? 'true'
-                                      : ''));
+                                          .isNotEmpty ||
+                                      newInstallIdsAllOrSelected.isNotEmpty));
                             }
-                            showDialog<Map<String, String>?>(
+                            showDialog<Map<String, dynamic>?>(
                                 context: context,
                                 builder: (BuildContext ctx) {
                                   var totalApps = existingUpdateIdsAllOrSelected
@@ -453,11 +444,11 @@ class AppsPageState extends State<AppsPage> {
                                       [formItems]);
                                 }
                                 bool shouldInstallUpdates =
-                                    values['updates'] == 'true';
+                                    values['updates'] == true;
                                 bool shouldInstallNew =
-                                    values['installs'] == 'true';
+                                    values['installs'] == true;
                                 bool shouldMarkTrackOnlies =
-                                    values['trackonlies'] == 'true';
+                                    values['trackonlies'] == true;
                                 (() async {
                                   if (shouldInstallNew ||
                                       shouldInstallUpdates) {
@@ -699,7 +690,7 @@ class AppsPageState extends State<AppsPage> {
                               : FontWeight.bold),
                     ),
                     onPressed: () {
-                      showDialog<Map<String, String>?>(
+                      showDialog<Map<String, dynamic>?>(
                           context: context,
                           builder: (BuildContext ctx) {
                             var vals = filter == null
@@ -709,25 +700,23 @@ class AppsPageState extends State<AppsPage> {
                                 title: tr('filterApps'),
                                 items: [
                                   [
-                                    GeneratedFormItem('appName',
+                                    GeneratedFormTextField('appName',
                                         label: tr('appName'),
                                         required: false,
                                         defaultValue: vals['appName']),
-                                    GeneratedFormItem('author',
+                                    GeneratedFormTextField('author',
                                         label: tr('author'),
                                         required: false,
                                         defaultValue: vals['author'])
                                   ],
                                   [
-                                    GeneratedFormItem('upToDateApps',
+                                    GeneratedFormSwitch('upToDateApps',
                                         label: tr('upToDateApps'),
-                                        type: FormItemType.bool,
                                         defaultValue: vals['upToDateApps'])
                                   ],
                                   [
-                                    GeneratedFormItem('nonInstalledApps',
+                                    GeneratedFormSwitch('nonInstalledApps',
                                         label: tr('nonInstalledApps'),
-                                        type: FormItemType.bool,
                                         defaultValue: vals['nonInstalledApps'])
                                   ],
                                   [
@@ -768,21 +757,21 @@ class AppsFilter {
       this.includeNonInstalled = true,
       this.categoryFilter = ''});
 
-  Map<String, String> toValuesMap() {
+  Map<String, dynamic> toValuesMap() {
     return {
       'appName': nameFilter,
       'author': authorFilter,
-      'upToDateApps': includeUptodate ? 'true' : '',
-      'nonInstalledApps': includeNonInstalled ? 'true' : '',
+      'upToDateApps': includeUptodate,
+      'nonInstalledApps': includeNonInstalled,
       'category': categoryFilter
     };
   }
 
-  AppsFilter.fromValuesMap(Map<String, String> values) {
+  AppsFilter.fromValuesMap(Map<String, dynamic> values) {
     nameFilter = values['appName']!;
     authorFilter = values['author']!;
-    includeUptodate = values['upToDateApps'] == 'true';
-    includeNonInstalled = values['nonInstalledApps'] == 'true';
+    includeUptodate = values['upToDateApps'];
+    includeNonInstalled = values['nonInstalledApps'];
     categoryFilter = values['category']!;
   }
 

--- a/lib/pages/import_export.dart
+++ b/lib/pages/import_export.dart
@@ -138,18 +138,19 @@ class _ImportExportPageState extends State<ImportExportPage> {
                           onPressed: importInProgress
                               ? null
                               : () {
-                                  showDialog(
+                                  showDialog<Map<String, dynamic>?>(
                                       context: context,
                                       builder: (BuildContext ctx) {
                                         return GeneratedFormModal(
                                           title: tr('importFromURLList'),
                                           items: [
                                             [
-                                              GeneratedFormItem('appURLList',
+                                              GeneratedFormTextField(
+                                                  'appURLList',
                                                   label: tr('appURLList'),
                                                   max: 7,
                                                   additionalValidators: [
-                                                    (String? value) {
+                                                    (dynamic value) {
                                                       if (value != null &&
                                                           value.isNotEmpty) {
                                                         var lines = value
@@ -176,7 +177,8 @@ class _ImportExportPageState extends State<ImportExportPage> {
                                       }).then((values) {
                                     if (values != null) {
                                       var urls =
-                                          (values[0] as String).split('\n');
+                                          (values['appURLList'] as String)
+                                              .split('\n');
                                       setState(() {
                                         importInProgress = true;
                                       });
@@ -224,7 +226,8 @@ class _ImportExportPageState extends State<ImportExportPage> {
                                             : () {
                                                 () async {
                                                   var values = await showDialog<
-                                                          List<String>>(
+                                                          Map<String,
+                                                              dynamic>?>(
                                                       context: context,
                                                       builder:
                                                           (BuildContext ctx) {
@@ -235,7 +238,7 @@ class _ImportExportPageState extends State<ImportExportPage> {
                                                               ]),
                                                           items: [
                                                             [
-                                                              GeneratedFormItem(
+                                                              GeneratedFormTextField(
                                                                   'searchQuery',
                                                                   label: tr(
                                                                       'searchQuery'))
@@ -244,13 +247,17 @@ class _ImportExportPageState extends State<ImportExportPage> {
                                                         );
                                                       });
                                                   if (values != null &&
-                                                      values[0].isNotEmpty) {
+                                                      (values['searchQuery']
+                                                                  as String?)
+                                                              ?.isNotEmpty ==
+                                                          true) {
                                                     setState(() {
                                                       importInProgress = true;
                                                     });
                                                     var urlsWithDescriptions =
-                                                        await source
-                                                            .search(values[0]);
+                                                        await source.search(
+                                                            values['searchQuery']
+                                                                as String);
                                                     if (urlsWithDescriptions
                                                         .isNotEmpty) {
                                                       var selectedUrls =
@@ -345,7 +352,7 @@ class _ImportExportPageState extends State<ImportExportPage> {
                                                                   .requiredArgs
                                                                   .map(
                                                                       (e) => [
-                                                                            GeneratedFormItem(e,
+                                                                            GeneratedFormTextField(e,
                                                                                 label: e)
                                                                           ])
                                                                   .toList(),

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -158,9 +158,10 @@ class _SettingsPageState extends State<SettingsPage> {
     var sourceSpecificFields = sourceProvider.sources.map((e) {
       if (e.additionalSourceSpecificSettingFormItems.isNotEmpty) {
         return GeneratedForm(
-            items: e.additionalSourceSpecificSettingFormItems
-                .map((e) => [e])
-                .toList(),
+            items: e.additionalSourceSpecificSettingFormItems.map((e) {
+              e.defaultValue = settingsProvider.getSettingString(e.key);
+              return [e];
+            }).toList(),
             onValueChanges: (values, valid, isBuilding) {
               if (valid) {
                 values.forEach((key, value) {
@@ -274,7 +275,7 @@ class _SettingsPageState extends State<SettingsPage> {
                                         backgroundColor: Color(e.value),
                                         visualDensity: VisualDensity.compact,
                                         onDeleted: () {
-                                          showDialog<Map<String, String>?>(
+                                          showDialog<Map<String, dynamic>?>(
                                               context: context,
                                               builder: (BuildContext ctx) {
                                                 return GeneratedFormModal(
@@ -311,14 +312,15 @@ class _SettingsPageState extends State<SettingsPage> {
                                         horizontal: 4),
                                     child: IconButton(
                                       onPressed: () {
-                                        showDialog<Map<String, String>?>(
+                                        showDialog<Map<String, dynamic>?>(
                                             context: context,
                                             builder: (BuildContext ctx) {
                                               return GeneratedFormModal(
                                                   title: tr('addCategory'),
                                                   items: [
                                                     [
-                                                      GeneratedFormItem('label',
+                                                      GeneratedFormTextField(
+                                                          'label',
                                                           label: tr('label'))
                                                     ]
                                                   ]);

--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -313,7 +313,7 @@ class AppsProvider with ChangeNotifier {
         throw ObtainiumError(tr('appNotFound'));
       }
       String? apkUrl;
-      var trackOnly = apps[id]!.app.additionalSettings['trackOnly'] == 'true';
+      var trackOnly = apps[id]!.app.additionalSettings['trackOnly'] == true;
       if (!trackOnly) {
         apkUrl = await confirmApkUrl(apps[id]!.app, context);
       }
@@ -452,9 +452,9 @@ class AppsProvider with ChangeNotifier {
   // Don't save changes, just return the object if changes were made (else null)
   App? getCorrectedInstallStatusAppIfPossible(App app, AppInfo? installedInfo) {
     var modded = false;
-    var trackOnly = app.additionalSettings['trackOnly'] == 'true';
+    var trackOnly = app.additionalSettings['trackOnly'] == true;
     var noVersionDetection =
-        app.additionalSettings['noVersionDetection'] == 'true';
+        app.additionalSettings['noVersionDetection'] == true;
     if (installedInfo == null && app.installedVersion != null && !trackOnly) {
       app.installedVersion = null;
       modded = true;

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -155,12 +155,12 @@ class SettingsProvider with ChangeNotifier {
     prefs?.setString('categories', jsonEncode(cats));
   }
 
-  getCategoryFormItem({String initCategory = ''}) =>
-      GeneratedFormItem('category',
-          label: tr('category'),
-          opts: [
-            MapEntry('', tr('noCategory')),
-            ...categories.entries.map((e) => MapEntry(e.key, e.key)).toList()
-          ],
-          defaultValue: initCategory);
+  getCategoryFormItem({String initCategory = ''}) => GeneratedFormDropdown(
+      'category',
+      label: tr('category'),
+      [
+        MapEntry('', tr('noCategory')),
+        ...categories.entries.map((e) => MapEntry(e.key, e.key)).toList()
+      ],
+      defaultValue: initCategory);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.9.1+89 # When changing this, update the tag in main() accordingly
+version: 0.9.2+90 # When changing this, update the tag in main() accordingly
 
 environment:
   sdk: '>=2.18.2 <3.0.0'


### PR DESCRIPTION
Breaking `GeneratedFormItem` into sub-types will let us more easily implement specialized functionality for each type. This is being done in preparation for a "tags" input type to use with the categorization UI.

This PR also fixes a bug where the GitHub PAT input does not load the saved value.