### PR TITLE
Same-versionCode Updates no Longer Skipped + 1 Other Bugfix

### DIFF
--- a/lib/app_sources/github.dart
+++ b/lib/app_sources/github.dart
@@ -141,10 +141,13 @@ class GitHub extends AppSource {
         if (!includePrereleases && releases[i]['prerelease'] == true) {
           continue;
         }
-
+        var nameToFilter = releases[i]['name'] as String;
+        if (nameToFilter.trim().isEmpty) {
+          // Some leave titles empty so tag is used
+          nameToFilter = releases[i]['tag_name'] as String;
+        }
         if (regexFilter != null &&
-            !RegExp(regexFilter)
-                .hasMatch((releases[i]['name'] as String).trim())) {
+            !RegExp(regexFilter).hasMatch(nameToFilter.trim())) {
           continue;
         }
         var apkUrls = getReleaseAPKUrls(releases[i]);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,7 +21,7 @@ import 'package:easy_localization/src/easy_localization_controller.dart';
 // ignore: implementation_imports
 import 'package:easy_localization/src/localization.dart';
 
-const String currentVersion = '0.9.14';
+const String currentVersion = '0.9.15';
 const String currentReleaseTag =
     'v$currentVersion-beta'; // KEEP THIS IN SYNC WITH GITHUB RELEASES
 

--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -247,10 +247,7 @@ class AppsProvider with ChangeNotifier {
         !(await canDowngradeApps())) {
       throw DowngradeError();
     }
-    if (appInfo == null ||
-        int.parse(newInfo.buildNumber) > appInfo.versionCode!) {
-      await InstallPlugin.installApk(file.file.path, 'dev.imranr.obtainium');
-    }
+    await InstallPlugin.installApk(file.file.path, 'dev.imranr.obtainium');
     apps[file.appId]!.app.installedVersion =
         apps[file.appId]!.app.latestVersion;
     // Don't correct install status as installation may not be done yet

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.9.14+104 # When changing this, update the tag in main() accordingly
+version: 0.9.15+105 # When changing this, update the tag in main() accordingly
 
 environment:
   sdk: '>=2.18.2 <3.0.0'


### PR DESCRIPTION
- Obtainium would skip installing APKs that had the same [`versionCode`](https://developer.android.com/studio/publish/versioning#versioningsettings) since this number should be different for each new build of an App.
    - However, there are enough Apps that don't do this (#149, #219) so Obtainium now installs updates even if the `versionCode` has not changed.
- The GitHub release title filter has also been improved so that it filters by `tag_name` instead of `title` for releases with empty titles (as it seems like GitHub automatically displays the tag as the title in such cases).