### PR TITLE
Add flutter as a submodule for reproducible build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".flutter"]
+	path = .flutter
+	url = https://github.com/flutter/flutter/


### PR DESCRIPTION
ATM, there is only one flutter app with the reproducible build on fdroid: https://gitlab.com/fdroid/fdroiddata/-/merge_requests/12398

In order to get a reproducible build with flutter:
* flutter must be the exact same commit : that's why this PR set it as a git submodule (update the PATH afterward). [0]
* The full path to the project must be the same too. It is suggested to use /tmp/build : `ln -s $(pwd) /tmp/build ; cd /tmp/build`. Of course, if you want to use a github action for the build process, you won't even notice the path used :)

[0] Note: To fetch the current submodule code: `git submodule update` and to update it: `git submodule update --remote`