### PR TITLE
Add an amoled black theme

### DIFF
--- a/assets/translations/de.json
+++ b/assets/translations/de.json
@@ -122,6 +122,7 @@
     "followSystem": "System folgen",
     "obtainium": "Obtainium",
     "materialYou": "Material You",
+    "useBlackTheme": "Use pure black dark theme",
     "appSortBy": "App sortieren nach",
     "authorName": "Autor/Name",
     "nameAuthor": "Name/Autor",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -122,6 +122,7 @@
     "followSystem": "Follow System",
     "obtainium": "Obtainium",
     "materialYou": "Material You",
+    "useBlackTheme": "Use pure black dark theme",
     "appSortBy": "App Sort By",
     "authorName": "Author/Name",
     "nameAuthor": "Name/Author",

--- a/assets/translations/fa.json
+++ b/assets/translations/fa.json
@@ -122,6 +122,7 @@
     "followSystem": "هماهنگ با سیستم",
     "obtainium": "Obtainium",
     "materialYou": "Material You",
+    "useBlackTheme": "Use pure black dark theme",
     "appSortBy": "مرتب سازی برنامه بر اساس",
     "authorName": "سازنده/اسم",
     "nameAuthor": "اسم/سازنده",

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -122,6 +122,7 @@
     "followSystem": "Suivre le système",
     "obtainium": "Obtainium",
     "materialYou": "Material You",
+    "useBlackTheme": "Use pure black dark theme",
     "appSortBy": "Applications triées par",
     "authorName": "Auteur/Nom",
     "nameAuthor": "Nom/Auteur",

--- a/assets/translations/hu.json
+++ b/assets/translations/hu.json
@@ -122,6 +122,7 @@
     "followSystem": "Rendszer szerint",
     "obtainium": "Obtainium",
     "materialYou": "Material You",
+    "useBlackTheme": "Use pure black dark theme",
     "appSortBy": "App rendezés...",
     "authorName": "Szerző/Név",
     "nameAuthor": "Név/Szerző",

--- a/assets/translations/it.json
+++ b/assets/translations/it.json
@@ -122,6 +122,7 @@
     "followSystem": "Segui sistema",
     "obtainium": "Obtainium",
     "materialYou": "Material You",
+    "useBlackTheme": "Use pure black dark theme",
     "appSortBy": "App ordinate per",
     "authorName": "Autore/Nome",
     "nameAuthor": "Nome/Autore",

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -122,6 +122,7 @@
     "followSystem": "システムに従う",
     "obtainium": "Obtainium",
     "materialYou": "Material You",
+    "useBlackTheme": "Use pure black dark theme",
     "appSortBy": "アプリの並び方",
     "authorName": "作者名/アプリ名",
     "nameAuthor": "アプリ名/作者名",

--- a/assets/translations/zh.json
+++ b/assets/translations/zh.json
@@ -123,6 +123,7 @@
     "followSystem": "跟随系统",
     "obtainium": "Obtainium",
     "materialYou": "Material You",
+    "useBlackTheme": "Use pure black dark theme",
     "appSortBy": "排列方式",
     "authorName": "作者 / 名字",
     "nameAuthor": "名字 / 作者",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -263,6 +263,14 @@ class _ObtainiumState extends State<Obtainium> {
         darkColorScheme = ColorScheme.fromSeed(
             seedColor: defaultThemeColour, brightness: Brightness.dark);
       }
+
+      // set the background and surface colors to pure black in the amoled theme
+      if (settingsProvider.useBlackTheme) {
+        darkColorScheme = darkColorScheme
+            .copyWith(background: Colors.black, surface: Colors.black)
+            .harmonized();
+      }
+
       return MaterialApp(
           title: 'Obtainium',
           localizationsDelegates: context.localizationDelegates,

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -224,6 +224,17 @@ class _SettingsPageState extends State<SettingsPage> {
                             ),
                             themeDropdown,
                             height16,
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: [
+                                Text(tr('useBlackTheme')),
+                                Switch(
+                                    value: settingsProvider.useBlackTheme,
+                                    onChanged: (value) {
+                                      settingsProvider.useBlackTheme = value;
+                                    })
+                              ],
+                            ),
                             colourDropdown,
                             height16,
                             Row(

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -64,6 +64,15 @@ class SettingsProvider with ChangeNotifier {
     notifyListeners();
   }
 
+  bool get useBlackTheme {
+    return prefs?.getBool('useBlackTheme') ?? false;
+  }
+
+  set useBlackTheme(bool useBlackTheme) {
+    prefs?.setBool('useBlackTheme', useBlackTheme);
+    notifyListeners();
+  }
+
   int get updateInterval {
     var min = prefs?.getInt('updateInterval') ?? 360;
     if (!updateIntervals.contains(min)) {


### PR DESCRIPTION
This PR adds a switch to enable a pure black (amoled) theme, works for both the Obtainium and the Material You theme.

closes #155