### PR TITLE
Fix out of memory error for large xapk's

### DIFF
--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -27,7 +27,7 @@ import 'package:flutter_fgbg/flutter_fgbg.dart';
 import 'package:obtainium/providers/source_provider.dart';
 import 'package:http/http.dart';
 import 'package:android_intent_plus/android_intent.dart';
-import 'package:archive/archive.dart';
+import 'package:archive/archive_io.dart';
 
 class AppInMemory {
   late App app;
@@ -333,20 +333,9 @@ class AppsProvider with ChangeNotifier {
   }
 
   void unzipFile(String filePath, String destinationPath) {
-    final bytes = File(filePath).readAsBytesSync();
-    final archive = ZipDecoder().decodeBytes(bytes);
-
-    for (final file in archive) {
-      final filename = '$destinationPath/${file.name}';
-      if (file.isFile) {
-        final data = file.content as List<int>;
-        File(filename)
-          ..createSync(recursive: true)
-          ..writeAsBytesSync(data);
-      } else {
-        Directory(filename).create(recursive: true);
-      }
-    }
+    final inputStream = InputFileStream(filePath);
+    final archive = ZipDecoder().decodeBuffer(inputStream);
+    extractArchiveToDisk(archive, destinationPath);
   }
 
   Future<void> installXApkDir(DownloadedXApkDir dir,


### PR DESCRIPTION
This PR changes how Obtainium extracts zip files. Obtainium currently loads the entire zip file to memory, which will throw an out of memory error for large apps.

Testing has been hard for this given the time to download each 1-2GB app and possible further issues with how Obtainium handles OBB's/Multi-APK's in xapks. Although these apps no longer fail to install, I haven't yet had one successfully run, have it's expected app size, or have it's OBB's in android/obb/
So I'm putting this as a draft PR until it can be determined if my implementation is the issue or not.