### PR TITLE
add OBB support

### DIFF
--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -393,8 +393,11 @@ class AppsProvider with ChangeNotifier {
   void moveObbFile(File file, String appId) async {
     if(!file.path.toLowerCase().endsWith('.obb')) return;
 
-    // REQUEST_INSTALL_PACKAGES is required to access Android/obb
-    // But it seems impossible to check if obb access has been explicitly granted
+    // TODO: Does not support Android 11+
+    if ((await DeviceInfoPlugin().androidInfo).version.sdkInt <= 29) {
+      await Permission.storage.request();
+    }
+
     String obbDirPath = "/storage/emulated/0/Android/obb/$appId";
     Directory(obbDirPath).createSync(recursive: true);
 

--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -350,7 +350,7 @@ class AppsProvider with ChangeNotifier {
               await installApk(DownloadedApk(dir.appId, file), silent: silent);
         }
         else if (file.path.toLowerCase().endsWith('.obb')) {
-          moveObbFile(file, dir.appId);
+          await moveObbFile(file, dir.appId);
         }
       }
       if (somethingInstalled) {
@@ -390,7 +390,7 @@ class AppsProvider with ChangeNotifier {
     return installed;
   }
 
-  void moveObbFile(File file, String appId) async {
+  Future<void> moveObbFile(File file, String appId) async {
     if(!file.path.toLowerCase().endsWith('.obb')) return;
 
     // TODO: Does not support Android 11+

--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -344,12 +344,14 @@ class AppsProvider with ChangeNotifier {
       {bool silent = false}) async {
     try {
       var somethingInstalled = false;
-      for (var apk in dir.extracted
-          .listSync()
-          .where((f) => f is File && f.path.toLowerCase().endsWith('.apk'))) {
-        somethingInstalled = somethingInstalled ||
-            await installApk(DownloadedApk(dir.appId, apk as File),
-                silent: silent);
+      for (var file in dir.extracted.listSync(recursive: true, followLinks: true).whereType<File>()) {
+        if (file.path.toLowerCase().endsWith('.apk')) {
+          somethingInstalled = somethingInstalled ||
+              await installApk(DownloadedApk(dir.appId, file), silent: silent);
+        }
+        else if (file.path.toLowerCase().endsWith('.obb')) {
+          moveObbFile(file, dir.appId);
+        }
       }
       if (somethingInstalled) {
         dir.file.delete(recursive: true);
@@ -386,6 +388,18 @@ class AppsProvider with ChangeNotifier {
     }
     await saveApps([apps[file.appId]!.app]);
     return installed;
+  }
+
+  void moveObbFile(File file, String appId) async {
+    if(!file.path.toLowerCase().endsWith('.obb')) return;
+
+    // REQUEST_INSTALL_PACKAGES is required to access Android/obb
+    // But it seems impossible to check if obb access has been explicitly granted
+    String obbDirPath = "/storage/emulated/0/Android/obb/$appId";
+    Directory(obbDirPath).createSync();
+
+    String obbFileName = file.path.split("/").last;
+    await file.copy("$obbDirPath/$obbFileName");
   }
 
   void uninstallApp(String appId) async {

--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -344,7 +344,7 @@ class AppsProvider with ChangeNotifier {
       {bool silent = false}) async {
     try {
       var somethingInstalled = false;
-      for (var file in dir.extracted.listSync(recursive: true, followLinks: true).whereType<File>()) {
+      for (var file in dir.extracted.listSync(recursive: true, followLinks: false).whereType<File>()) {
         if (file.path.toLowerCase().endsWith('.apk')) {
           somethingInstalled = somethingInstalled ||
               await installApk(DownloadedApk(dir.appId, file), silent: silent);
@@ -396,7 +396,7 @@ class AppsProvider with ChangeNotifier {
     // REQUEST_INSTALL_PACKAGES is required to access Android/obb
     // But it seems impossible to check if obb access has been explicitly granted
     String obbDirPath = "/storage/emulated/0/Android/obb/$appId";
-    Directory(obbDirPath).createSync();
+    Directory(obbDirPath).createSync(recursive: true);
 
     String obbFileName = file.path.split("/").last;
     await file.copy("$obbDirPath/$obbFileName");


### PR DESCRIPTION
Supports android versions below 11 and OS's with toggles (such as grapheneOS)

It's purported that apps with REQUEST_INSTALL_PACKAGES can access Android/obb [but that's either bugged or false](https://issuetracker.google.com/issues/254445476)

Android 11 and 12 has [a work around which is quite hacky](https://blog.esper.io/android-dessert-bites-28-file-manager-loophole-closed-73891524/), but if thats ok I can add support in another PR
Android API 34 has worked with MANAGE_EXTERNAL_STORAGE, but I'm not sure if this will still be the case in the final release of android 14 so I removed the code for it.

closes #622 