### PR TITLE
change archive library

### DIFF
--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -27,7 +27,7 @@ import 'package:flutter_fgbg/flutter_fgbg.dart';
 import 'package:obtainium/providers/source_provider.dart';
 import 'package:http/http.dart';
 import 'package:android_intent_plus/android_intent.dart';
-import 'package:archive/archive_io.dart';
+import 'package:flutter_archive/flutter_archive.dart';
 
 class AppInMemory {
   late App app;
@@ -264,7 +264,7 @@ class AppsProvider with ChangeNotifier {
       } else {
         // Assume XAPK
         String xapkDirPath = '${downloadedFile.path}-dir';
-        unzipFile(downloadedFile.path, '${downloadedFile.path}-dir');
+        await unzipFile(downloadedFile.path, '${downloadedFile.path}-dir');
         xapkDir = Directory(xapkDirPath);
         var apks = xapkDir
             .listSync()
@@ -334,10 +334,8 @@ class AppsProvider with ChangeNotifier {
     }
   }
 
-  void unzipFile(String filePath, String destinationPath) {
-    final inputStream = InputFileStream(filePath);
-    final archive = ZipDecoder().decodeBuffer(inputStream);
-    extractArchiveToDisk(archive, destinationPath);
+  Future<void> unzipFile(String filePath, String destinationPath) async {
+    await ZipFile.extractToDirectory(zipFile: File(filePath), destinationDir: Directory(destinationPath));
   }
 
   Future<void> installXApkDir(DownloadedXApkDir dir,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -35,7 +35,7 @@ packages:
     source: hosted
     version: "2.0.7"
   archive:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: archive
       sha256: "0c8368c9b3f0abbc193b9d6133649a614204b528982bebc7026372d61677ce3a"
@@ -231,6 +231,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_archive:
+    dependency: "direct main"
+    description:
+      name: flutter_archive
+      sha256: aec85d1da65e5b33a529db00a86df0b8e92bda78088a7cfaeeba5187701d0d85
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
   flutter_fgbg:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,7 +63,7 @@ dependencies:
   easy_localization: ^3.0.1
   android_intent_plus: ^4.0.0
   flutter_markdown: ^0.6.14
-  archive: ^3.3.7
+  flutter_archive: ^5.0.0
 
 
 dev_dependencies:


### PR DESCRIPTION
PR #616 removed the need to load the zip file into memory, however the archive library itself also loads individual files into memory when writing. Considering that some xapk's are mainly comprised of a single obb file this is an issue.
Archive also suppresses any out of memory errors and writes the file but with zero bytes, giving no indication that it failed.
This PR replaces archive with the archive_flutter plugin, which will break files into blocks when writing.