### PR TITLE
fix race condition when checking updates

### DIFF
--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -902,7 +902,7 @@ class AppsProvider with ChangeNotifier {
     if (currentApp.preferredApkIndex < newApp.apkUrls.length) {
       newApp.preferredApkIndex = currentApp.preferredApkIndex;
     }
-    await saveApps([newApp]);
+    if (apps.containsKey(appId)) await saveApps([newApp]);
     return newApp.latestVersion != currentApp.latestVersion ? newApp : null;
   }
 

--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -787,8 +787,10 @@ class AppsProvider with ChangeNotifier {
       if (attemptToCorrectInstallStatus) {
         app = getCorrectedInstallStatusAppIfPossible(app, info) ?? app;
       }
-      File('${(await getAppsDir()).path}/${app.id}.json')
-          .writeAsStringSync(jsonEncode(app.toJson()));
+      if (!onlyIfExists || this.apps.containsKey(app.id)) {
+        File('${(await getAppsDir()).path}/${app.id}.json')
+            .writeAsStringSync(jsonEncode(app.toJson()));
+      }
       try {
         this.apps.update(
             app.id, (value) => AppInMemory(app, value.downloadProgress, info),
@@ -902,7 +904,7 @@ class AppsProvider with ChangeNotifier {
     if (currentApp.preferredApkIndex < newApp.apkUrls.length) {
       newApp.preferredApkIndex = currentApp.preferredApkIndex;
     }
-    if (apps.containsKey(appId)) await saveApps([newApp]);
+    await saveApps([newApp]);
     return newApp.latestVersion != currentApp.latestVersion ? newApp : null;
   }
 


### PR DESCRIPTION
Found when looking into #427
Wont link this PR to close as I'm not sure if these bugs are the same.

While checkUpdate waits on getApp, removeApps can remove the appID from the list and delete the json file. After getApp returns, checkUpdate will rewrite the json file.
This isn't an perfect fix as these functions can run at the same time. The only other fixes I can think of would be either refactoring practically all of apps_provider, or somehow synchronously calling getApp which would cause a massive delay whenever an app page is opened.
