### PR TITLE
added trim to appSourceURL value

### DIFF
--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -202,7 +202,7 @@ class _AddAppPageState extends State<AddAppPage> {
       }
     }
 
-  Widget getUrlInputRow() => Row(
+    Widget getUrlInputRow() => Row(
           children: [
             Expanded(
                 child: GeneratedForm(

--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -202,7 +202,7 @@ class _AddAppPageState extends State<AddAppPage> {
       }
     }
 
-    Widget getUrlInputRow() => Row(
+Widget getUrlInputRow() => Row(
           children: [
             Expanded(
                 child: GeneratedForm(
@@ -214,11 +214,12 @@ class _AddAppPageState extends State<AddAppPage> {
                             defaultValue: userInput,
                             additionalValidators: [
                               (value) {
+                                String trimmedValue = (value ?? '').trim();
                                 try {
                                   sourceProvider
-                                      .getSource(value ?? '',
+                                      .getSource(trimmedValue,
                                           overrideSource: pickedSourceOverride)
-                                      .standardizeUrl(value ?? '');
+                                      .standardizeUrl(trimmedValue);
                                 } catch (e) {
                                   return e is String
                                       ? e
@@ -233,7 +234,7 @@ class _AddAppPageState extends State<AddAppPage> {
                     ],
                     onValueChanges: (values, valid, isBuilding) {
                       changeUserInput(
-                          values['appSourceURL']!, valid, isBuilding);
+                          values['appSourceURL']!.trim(), valid, isBuilding);
                     })),
             const SizedBox(
               width: 16,

--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -202,7 +202,7 @@ class _AddAppPageState extends State<AddAppPage> {
       }
     }
 
-Widget getUrlInputRow() => Row(
+  Widget getUrlInputRow() => Row(
           children: [
             Expanded(
                 child: GeneratedForm(


### PR DESCRIPTION
Currently when you add an App.
In the App Source URL field if there is an extra space in the end it does not work.

Perhaps a simple .trim() should do the trick?
![image](https://github.com/ImranR98/Obtainium/assets/68999840/78d90bbd-765d-42bb-a66c-2bcc8c9a5cff)
