### PR TITLE
Resize adaptative icon to 108x108dp (#1142)

### DIFF
--- a/android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,8 +1,8 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt"
     android:viewportWidth="142.129"
     android:viewportHeight="142.129"
-    android:width="503.6066dp"
-    android:height="503.6066dp">
+    android:width="108dp"
+    android:height="108dp">
     <group
         android:translateX="-30.39437"
         android:translateY="-54.68043">


### PR DESCRIPTION
Android documentation [1] explicity specify that adaptive icons must be 108x108dp.
Having bigger Adaptive icons triggers a bug in Android 14 QPR1 that prevent to install apps from apk directly when the icons are bigger.

[1] https://developer.android.com/develop/ui/views/launch/icon_design_adaptive