### PR TITLE
added missing strings in some languages, translated for DE

### DIFF
--- a/assets/translations/bs.json
+++ b/assets/translations/bs.json
@@ -283,6 +283,11 @@
     "supportFixedAPKURL": "Podržite fiksne APK URL-ove",
     "selectX": "Izaberite {}",
     "parallelDownloads": "Allow parallel downloads",
+    "installMethod": "Installation method",
+    "normal": "Normal",
+    "shizuku": "Shizuku",
+    "root": "Root",
+    "shizukuBinderNotFound": "Shizuku is not running",
     "removeAppQuestion": {
         "one": "Želite li ukloniti aplikaciju?",
         "other": "Želite li ukloniti aplikacije?"

--- a/assets/translations/de.json
+++ b/assets/translations/de.json
@@ -283,6 +283,11 @@
     "supportFixedAPKURL": "neuere Version anhand der ersten dreißig Zahlen der Checksumme der APK URL erraten, wenn anderweitig nicht unterstützt",
     "selectX": "Wähle {}",
     "parallelDownloads": "Erlaube parallele Downloads",
+    "installMethod": "Installationsmethode",
+    "normal": "Normal",
+    "shizuku": "Shizuku",
+    "root": "Root",
+    "shizukuBinderNotFound": "Shizuku läuft nicht",
     "removeAppQuestion": {
         "one": "App entfernen?",
         "other": "Apps entfernen?"

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -283,6 +283,11 @@
     "supportFixedAPKURL": "Soporte para URLs fijas de APK",
     "selectX": "Selecciona {}",
     "parallelDownloads": "Permitir descargas paralelas",
+    "installMethod": "Installation method",
+    "normal": "Normal",
+    "shizuku": "Shizuku",
+    "root": "Root",
+    "shizukuBinderNotFound": "Shizuku is not running",
     "removeAppQuestion": {
         "one": "¿Eliminar Aplicación?",
         "other": "¿Eliminar Aplicaciones?"

--- a/assets/translations/fa.json
+++ b/assets/translations/fa.json
@@ -283,6 +283,11 @@
     "supportFixedAPKURL": "پشتیبانی از URL های APK ثابت",
     "selectX": "انتخاب کنید {}",
     "parallelDownloads": "Allow parallel downloads",
+    "installMethod": "Installation method",
+    "normal": "Normal",
+    "shizuku": "Shizuku",
+    "root": "Root",
+    "shizukuBinderNotFound": "Shizuku is not running",
     "removeAppQuestion": {
         "one": "برنامه حذف شود؟",
         "other": "برنامه ها حذف شوند؟"

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -283,6 +283,11 @@
     "supportFixedAPKURL": "Support fixed APK URLs",
     "selectX": "Select {}",
     "parallelDownloads": "Allow parallel downloads",
+    "installMethod": "Installation method",
+    "normal": "Normal",
+    "shizuku": "Shizuku",
+    "root": "Root",
+    "shizukuBinderNotFound": "Shizuku is not running",
     "removeAppQuestion": {
         "one": "Supprimer l'application ?",
         "other": "Supprimer les applications ?"

--- a/assets/translations/hu.json
+++ b/assets/translations/hu.json
@@ -283,6 +283,11 @@
     "supportFixedAPKURL": "Támogatja a rögzített APK URL-eket",
     "selectX": "Kiválaszt {}",
     "parallelDownloads": "Párhuzamos letöltéseket enged",
+    "installMethod": "Installation method",
+    "normal": "Normal",
+    "shizuku": "Shizuku",
+    "root": "Root",
+    "shizukuBinderNotFound": "Shizuku is not running",
     "removeAppQuestion": {
         "one": "Eltávolítja az alkalmazást?",
         "other": "Eltávolítja az alkalmazást?"

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -283,6 +283,11 @@
     "supportFixedAPKURL": "Support fixed APK URLs",
     "selectX": "Select {}",
     "parallelDownloads": "Allow parallel downloads",
+    "installMethod": "Installation method",
+    "normal": "Normal",
+    "shizuku": "Shizuku",
+    "root": "Root",
+    "shizukuBinderNotFound": "Shizuku is not running",
     "removeAppQuestion": {
         "one": "アプリを削除しますか？",
         "other": "アプリを削除しますか？"

--- a/assets/translations/nl.json
+++ b/assets/translations/nl.json
@@ -283,6 +283,11 @@
     "supportFixedAPKURL": "Support fixed APK URLs",
     "selectX": "Select {}",
     "parallelDownloads": "Allow parallel downloads",
+    "installMethod": "Installation method",
+    "normal": "Normal",
+    "shizuku": "Shizuku",
+    "root": "Root",
+    "shizukuBinderNotFound": "Shizuku is not running",
     "removeAppQuestion": {
         "one": "App verwijderen?",
         "other": "Apps verwijderen?"

--- a/assets/translations/pl.json
+++ b/assets/translations/pl.json
@@ -283,6 +283,11 @@
     "supportFixedAPKURL": "Obsługuj stałe adresy URL APK",
     "selectX": "Wybierz {}",
     "parallelDownloads": "Allow parallel downloads",
+    "installMethod": "Installation method",
+    "normal": "Normal",
+    "shizuku": "Shizuku",
+    "root": "Root",
+    "shizukuBinderNotFound": "Shizuku is not running",
     "removeAppQuestion": {
         "one": "Usunąć aplikację?",
         "few": "Usunąć aplikacje?",

--- a/assets/translations/sv.json
+++ b/assets/translations/sv.json
@@ -269,6 +269,11 @@
     "bgTaskStarted": "Background task started - check logs.",
     "runBgCheckNow": "Kör Bakgrundsuppdateringskoll Nu",
     "parallelDownloads": "Allow parallel downloads",
+    "installMethod": "Installation method",
+    "normal": "Normal",
+    "shizuku": "Shizuku",
+    "root": "Root",
+    "shizukuBinderNotFound": "Shizuku is not running",
     "removeAppQuestion": {
         "one": "Ta Bort App?",
         "other": "Ta Bort Appar?"

--- a/assets/translations/tr.json
+++ b/assets/translations/tr.json
@@ -283,6 +283,11 @@
     "supportFixedAPKURL": "Support fixed APK URLs",
     "selectX": "Select {}",
     "parallelDownloads": "Allow parallel downloads",
+    "installMethod": "Installation method",
+    "normal": "Normal",
+    "shizuku": "Shizuku",
+    "root": "Root",
+    "shizukuBinderNotFound": "Shizuku is not running",
     "removeAppQuestion": {
         "one": "Uygulamayı Kaldır?",
         "other": "Uygulamaları Kaldır?"

--- a/assets/translations/vi.json
+++ b/assets/translations/vi.json
@@ -283,6 +283,11 @@
     "supportFixedAPKURL": "Support fixed APK URLs",
     "selectX": "Select {}",
     "parallelDownloads": "Allow parallel downloads",
+    "installMethod": "Installation method",
+    "normal": "Normal",
+    "shizuku": "Shizuku",
+    "root": "Root",
+    "shizukuBinderNotFound": "Shizuku is not running",
     "removeAppQuestion":{
         "one": "Gỡ ứng dụng?",
         "other": "Gỡ ứng dụng?"


### PR DESCRIPTION
```
    "installMethod": "Installation method",
    "normal": "Normal",
    "shizuku": "Shizuku",
    "root": "Root",
    "shizukuBinderNotFound": "Shizuku is not running",
```
were missing in some languages