### PR TITLE
Remove reference to old plugin to avoid crashes (#1221), Confirmation box for link-based imports (#1232), Construct extracted versions from match groups (#1235), Fix the WebView 'cleartext' error caused by HTTP sites (#1235), Make GitHub's (and Codeberg's) "fallback" work with the APK filter (#1236), Make version extraction universal (#1237), HTML Bugfix (#1238)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,8 @@
         android:label="Obtainium"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
-        android:requestLegacyExternalStorage="true">
+        android:requestLegacyExternalStorage="true"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -44,21 +44,6 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
-        <service
-            android:name="dev.fluttercommunity.plus.androidalarmmanager.AlarmService"
-            android:permission="android.permission.BIND_JOB_SERVICE"
-            android:exported="false" />
-        <receiver
-            android:name="dev.fluttercommunity.plus.androidalarmmanager.AlarmBroadcastReceiver"
-            android:exported="false" />
-        <receiver
-            android:name="dev.fluttercommunity.plus.androidalarmmanager.RebootBroadcastReceiver"
-            android:enabled="false"
-            android:exported="false">
-            <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED" />
-            </intent-filter>
-        </receiver>
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="dev.imranr.obtainium"

--- a/lib/app_sources/github.dart
+++ b/lib/app_sources/github.dart
@@ -346,6 +346,11 @@ class GitHub extends AppSource {
           continue;
         }
         var apkUrls = getReleaseAPKUrls(releases[i]);
+        if (additionalSettings['apkFilterRegEx'] != null) {
+          var reg = RegExp(additionalSettings['apkFilterRegEx']);
+          apkUrls =
+              apkUrls.where((element) => reg.hasMatch(element.key)).toList();
+        }
         if (apkUrls.isEmpty && additionalSettings['trackOnly'] != true) {
           continue;
         }

--- a/lib/app_sources/html.dart
+++ b/lib/app_sources/html.dart
@@ -242,9 +242,14 @@ class HTML extends AppSource {
     Map<String, dynamic> additionalSettings,
   ) async {
     var currentUrl = standardUrl;
-    for (int i = 0;
-        i < (additionalSettings['intermediateLink']?.length ?? 0);
-        i++) {
+    if (additionalSettings['intermediateLink']?.isNotEmpty != true) {
+      additionalSettings['intermediateLink'] = [];
+    }
+    additionalSettings['intermediateLink'] =
+        additionalSettings['intermediateLink']
+            .where((l) => l['customLinkFilterRegex'].isNotEmpty == true)
+            .toList();
+    for (int i = 0; i < (additionalSettings['intermediateLink'].length); i++) {
       var intLinks = await grabLinksCommon(await sourceRequest(currentUrl),
           additionalSettings['intermediateLink'][i]);
       if (intLinks.isEmpty) {

--- a/lib/app_sources/html.dart
+++ b/lib/app_sources/html.dart
@@ -252,26 +252,12 @@ class HTML extends AppSource {
     if (additionalSettings['supportFixedAPKURL'] != true) {
       version = rel.hashCode.toString();
     }
-    var versionExtractionRegEx =
-        additionalSettings['versionExtractionRegEx'] as String?;
-    if (versionExtractionRegEx?.isNotEmpty == true) {
-      var match = RegExp(versionExtractionRegEx!).allMatches(
-          additionalSettings['versionExtractWholePage'] == true
-              ? res.body.split('\r\n').join('\n').split('\n').join('\\n')
-              : rel);
-      if (match.isEmpty) {
-        throw NoVersionError();
-      }
-      String matchGroupString =
-          (additionalSettings['matchGroupToUse'] as String).trim();
-      if (matchGroupString.isEmpty) {
-        matchGroupString = "0";
-      }
-      version = match.last.group(int.parse(matchGroupString));
-      if (version?.isNotEmpty != true) {
-        throw NoVersionError();
-      }
-    }
+    version = extractVersion(
+        additionalSettings['versionExtractionRegEx'] as String?,
+        additionalSettings['matchGroupToUse'] as String?,
+        additionalSettings['versionExtractWholePage'] == true
+            ? res.body.split('\r\n').join('\n').split('\n').join('\\n')
+            : rel);
     rel = ensureAbsoluteUrl(rel, uri);
     version ??= (await checkDownloadHash(rel)).toString();
     return APKDetails(version, [rel].map((e) => MapEntry(e, e)).toList(),

--- a/lib/app_sources/html.dart
+++ b/lib/app_sources/html.dart
@@ -1,5 +1,4 @@
 import 'package:easy_localization/easy_localization.dart';
-import 'package:flutter/material.dart';
 import 'package:html/parser.dart';
 import 'package:http/http.dart';
 import 'package:obtainium/components/generated_form.dart';
@@ -97,28 +96,6 @@ class HTML extends AppSource {
           additionalValidators: [
             (value) {
               return regExValidator(value);
-            }
-          ])
-    ],
-    [
-      GeneratedFormTextField('versionExtractionRegEx',
-          label: tr('versionExtractionRegEx'),
-          required: false,
-          additionalValidators: [(value) => regExValidator(value)]),
-    ],
-    [
-      GeneratedFormTextField('matchGroupToUse',
-          label: tr('matchGroupToUse'),
-          required: false,
-          hint: '0',
-          textInputType: const TextInputType.numberWithOptions(),
-          additionalValidators: [
-            (value) {
-              if (value?.isEmpty == true) {
-                value = null;
-              }
-              value ??= '0';
-              return intValidator(value);
             }
           ])
     ],
@@ -291,7 +268,7 @@ class HTML extends AppSource {
         matchGroupString = "0";
       }
       version = match.last.group(int.parse(matchGroupString));
-      if (version?.isEmpty == true) {
+      if (version?.isNotEmpty != true) {
         throw NoVersionError();
       }
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,7 +19,7 @@ import 'package:easy_localization/src/easy_localization_controller.dart';
 // ignore: implementation_imports
 import 'package:easy_localization/src/localization.dart';
 
-const String currentVersion = '0.15.3';
+const String currentVersion = '0.15.4';
 const String currentReleaseTag =
     'v$currentVersion-beta'; // KEEP THIS IN SYNC WITH GITHUB RELEASES
 

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -5,6 +5,7 @@ import 'package:app_links/app_links.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:obtainium/components/generated_form_modal.dart';
 import 'package:obtainium/custom_errors.dart';
 import 'package:obtainium/pages/add_app.dart';
 import 'package:obtainium/pages/apps.dart';
@@ -76,14 +77,39 @@ class _HomePageState extends State<HomePage> {
       try {
         if (action == 'add') {
           await goToAddApp(data);
-        } else if (action == 'app') {
-          await context
-              .read<AppsProvider>()
-              .import('{ "apps": [${Uri.decodeComponent(data)}] }');
-        } else if (action == 'apps') {
-          await context
-              .read<AppsProvider>()
-              .import('{ "apps": ${Uri.decodeComponent(data)} }');
+        } else if (action == 'app' || action == 'apps') {
+          var dataStr = Uri.decodeComponent(data);
+          if (await showDialog(
+                  context: context,
+                  builder: (BuildContext ctx) {
+                    return GeneratedFormModal(
+                      title: tr('importX', args: [
+                        action == 'app' ? tr('app') : tr('appsString')
+                      ]),
+                      items: const [],
+                      additionalWidgets: [
+                        ExpansionTile(
+                          title: const Text('Raw JSON'),
+                          children: [
+                            Text(
+                              dataStr,
+                              style: const TextStyle(fontFamily: 'monospace'),
+                            )
+                          ],
+                        )
+                      ],
+                    );
+                  }) !=
+              null) {
+            // ignore: use_build_context_synchronously
+            var result = await context.read<AppsProvider>().import(
+                action == 'app'
+                    ? '{ "apps": [$dataStr] }'
+                    : '{ "apps": $dataStr }');
+            // ignore: use_build_context_synchronously
+            showMessage(
+                tr('importedX', args: [plural('apps', result.key)]), context);
+          }
         } else {
           throw ObtainiumError(tr('unknown'));
         }

--- a/lib/providers/source_provider.dart
+++ b/lib/providers/source_provider.dart
@@ -603,6 +603,28 @@ bool isTempId(App app) {
   return RegExp('^[0-9]+\$').hasMatch(app.id);
 }
 
+String? extractVersion(String? versionExtractionRegEx, String? matchGroupString,
+    String stringToCheck) {
+  if (versionExtractionRegEx?.isNotEmpty == true) {
+    String? version = stringToCheck;
+    var match = RegExp(versionExtractionRegEx!).allMatches(version);
+    if (match.isEmpty) {
+      throw NoVersionError();
+    }
+    matchGroupString = matchGroupString?.trim() ?? '';
+    if (matchGroupString.isEmpty) {
+      matchGroupString = "0";
+    }
+    version = match.last.group(int.parse(matchGroupString));
+    if (version?.isNotEmpty != true) {
+      throw NoVersionError();
+    }
+    return version!;
+  } else {
+    return null;
+  }
+}
+
 class SourceProvider {
   // Add more source classes here so they are available via the service
   List<AppSource> get sources => [
@@ -705,24 +727,12 @@ class SourceProvider {
 
     if (source.runtimeType != HTML().runtimeType) {
       // HTML does it separately
-      var versionExtractionRegEx =
-          additionalSettings['versionExtractionRegEx'] as String?;
-      if (versionExtractionRegEx?.isNotEmpty == true) {
-        String? version = apk.version;
-        var match = RegExp(versionExtractionRegEx!).allMatches(apk.version);
-        if (match.isEmpty) {
-          throw NoVersionError();
-        }
-        String matchGroupString =
-            (additionalSettings['matchGroupToUse'] as String).trim();
-        if (matchGroupString.isEmpty) {
-          matchGroupString = "0";
-        }
-        version = match.last.group(int.parse(matchGroupString));
-        if (version?.isNotEmpty != true) {
-          throw NoVersionError();
-        }
-        apk.version = version!;
+      String? extractedVersion = extractVersion(
+          additionalSettings['versionExtractionRegEx'] as String?,
+          additionalSettings['matchGroupToUse'] as String?,
+          apk.version);
+      if (extractedVersion != null) {
+        apk.version = extractedVersion;
       }
     }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -46,10 +46,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: "7b875fd4a20b165a3084bd2d210439b22ebc653f21cea4842729c0c30c82596b"
+      sha256: "22600aa1e926be775fa5fe7e6894e7fb3df9efda8891c73f70fb3262399a432d"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.9"
+    version: "3.4.10"
   args:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.15.3+239 # When changing this, update the tag in main() accordingly
+version: 0.15.4+240 # When changing this, update the tag in main() accordingly
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
- Remove reference to old plugin to avoid crashes (#1221)
- Confirmation box for link-based imports (#1232)
- Construct extracted versions from match groups (#1235)
- Fix the WebView 'cleartext' error caused by HTTP sites (#1235)
- Make GitHub's (and Codeberg's) "fallback" work with the APK filter (#1236)
- Make version extraction universal (#1237)
- HTML Bugfix (#1238)