### PR TITLE
Improve loading time (parallelize version detection), Newest asset upload date as release date for GitHub (#1284), Enable 'start on boot' for BG task (#1234), Remove the need to hardcode Obtainium's version number

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,12 @@ name: Build and Release
 
 on:
   workflow_dispatch:
+    inputs:
+      beta:
+        type: boolean
+        description: Is beta?
+      environment:
+        type: environment
     
 jobs:
   build:
@@ -47,12 +53,13 @@ jobs:
       - name: Extract Version
         id: extract_version      
         run: |
-           VERSION=$(grep -oP "currentVersion = '\K[^']+" lib/main.dart)
+           VERSION=$(grep -oP "^version: [^\+]+" pubspec.yaml | tail -c +10)
            echo "version=$VERSION" >> $GITHUB_OUTPUT
-           TAG=$(grep -oP "'.*\\\$currentVersion.*'" lib/main.dart | head -c -2 | tail -c +2 | sed "s/\$currentVersion/$VERSION/g")
-           echo "tag=$TAG" >> $GITHUB_OUTPUT
-           if [ -n "$(echo $TAG | grep -oP '\-beta$')" ]; then BETA=true; else BETA=false; fi
+           if [ ${{ inputs.beta }} == true ]; then BETA=true; else BETA=false; fi
            echo "beta=$BETA" >> $GITHUB_OUTPUT
+           TAG="v$VERSION"
+           if [ $BETA == true ]; then TAG="$TAG"-beta; fi
+           echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Create Tag
         uses: mathieudutour/github-tag-action@v6.1

--- a/assets/translations/bs.json
+++ b/assets/translations/bs.json
@@ -291,6 +291,7 @@
     "shizukuBinderNotFound": "Shizuku is not running",
     "useVersionCodeAsOSVersion": "Use app versionCode as OS-detected version",
     "requestHeader": "Request header",
+    "useLatestAssetDateAsReleaseDate": "Use latest asset upload as release date",
     "removeAppQuestion": {
         "one": "Želite li ukloniti aplikaciju?",
         "other": "Želite li ukloniti aplikacije?"

--- a/assets/translations/cs.json
+++ b/assets/translations/cs.json
@@ -291,6 +291,7 @@
     "shizukuBinderNotFound": "Shizuku neběží",
     "useVersionCodeAsOSVersion": "Use app versionCode as OS-detected version",
     "requestHeader": "Request header",
+    "useLatestAssetDateAsReleaseDate": "Use latest asset upload as release date",
     "removeAppQuestion": {
         "one": "Odstranit Apku?",
         "other": "Odstranit Apky?"

--- a/assets/translations/de.json
+++ b/assets/translations/de.json
@@ -291,6 +291,7 @@
     "shizukuBinderNotFound": "Shizuku läuft nicht",
     "useVersionCodeAsOSVersion": "Use app versionCode as OS-detected version",
     "requestHeader": "Request header",
+    "useLatestAssetDateAsReleaseDate": "Use latest asset upload as release date",
     "removeAppQuestion": {
         "one": "App entfernen?",
         "other": "Apps entfernen?"

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -293,6 +293,7 @@
     "systemFontError": "Error loading the system font: {}",
     "useVersionCodeAsOSVersion": "Use app versionCode as OS-detected version",
     "requestHeader": "Request header",
+    "useLatestAssetDateAsReleaseDate": "Use latest asset upload as release date",
     "removeAppQuestion": {
         "one": "Remove App?",
         "other": "Remove Apps?"

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -291,6 +291,7 @@
     "shizukuBinderNotFound": "Shizuku no está operativo",
     "useVersionCodeAsOSVersion": "Use app versionCode as OS-detected version",
     "requestHeader": "Request header",
+    "useLatestAssetDateAsReleaseDate": "Use latest asset upload as release date",
     "removeAppQuestion": {
         "one": "¿Eliminar Aplicación?",
         "other": "¿Eliminar Aplicaciones?"

--- a/assets/translations/fa.json
+++ b/assets/translations/fa.json
@@ -291,6 +291,7 @@
     "shizukuBinderNotFound": "Shizuku در حال اجرا نیست",
     "useVersionCodeAsOSVersion": "استفاده کد نسخه برنامه به جای نسخه شناسایی شده توسط سیستم عامل استفاده کنید",
     "requestHeader": "درخواست سطر بالایی",
+    "useLatestAssetDateAsReleaseDate": "Use latest asset upload as release date",
     "removeAppQuestion": {
         "one": "برنامه حذف شود؟",
         "other": "برنامه ها حذف شوند؟"

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -291,6 +291,7 @@
     "shizukuBinderNotFound": "Shizuku is not running",
     "useVersionCodeAsOSVersion": "Use app versionCode as OS-detected version",
     "requestHeader": "Request header",
+    "useLatestAssetDateAsReleaseDate": "Use latest asset upload as release date",
     "removeAppQuestion": {
         "one": "Supprimer l'application ?",
         "other": "Supprimer les applications ?"

--- a/assets/translations/hu.json
+++ b/assets/translations/hu.json
@@ -291,6 +291,7 @@
     "shizukuBinderNotFound": "A Shizuku nem fut",
     "useVersionCodeAsOSVersion": "Az app versionCode használata a rendszer által észlelt verzióként",
     "requestHeader": "Kérelem fejléc",
+    "useLatestAssetDateAsReleaseDate": "Use latest asset upload as release date",
     "removeAppQuestion": {
         "one": "Eltávolítja az alkalmazást?",
         "other": "Eltávolítja az alkalmazást?"

--- a/assets/translations/it.json
+++ b/assets/translations/it.json
@@ -291,6 +291,7 @@
     "shizukuBinderNotFound": "Shizuku non è in esecuzione",
     "useVersionCodeAsOSVersion": "Use app versionCode as OS-detected version",
     "requestHeader": "Request header",
+    "useLatestAssetDateAsReleaseDate": "Use latest asset upload as release date",
     "removeAppQuestion": {
         "one": "Rimuovere l'app?",
         "other": "Rimuovere le app?"

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -293,6 +293,7 @@
     "systemFontError": "システムフォントの読み込みエラー: {}",
     "useVersionCodeAsOSVersion": "Use app versionCode as OS-detected version",
     "requestHeader": "Request header",
+    "useLatestAssetDateAsReleaseDate": "Use latest asset upload as release date",
     "removeAppQuestion": {
         "one": "アプリを削除しますか？",
         "other": "アプリを削除しますか？"

--- a/assets/translations/nl.json
+++ b/assets/translations/nl.json
@@ -291,6 +291,7 @@
     "shizukuBinderNotFound": "Shizuku is not running",
     "useVersionCodeAsOSVersion": "Use app versionCode as OS-detected version",
     "requestHeader": "Request header",
+    "useLatestAssetDateAsReleaseDate": "Use latest asset upload as release date",
     "removeAppQuestion": {
         "one": "App verwijderen?",
         "other": "Apps verwijderen?"

--- a/assets/translations/pl.json
+++ b/assets/translations/pl.json
@@ -291,6 +291,7 @@
     "shizukuBinderNotFound": "Shizuku is not running",
     "useVersionCodeAsOSVersion": "Use app versionCode as OS-detected version",
     "requestHeader": "Request header",
+    "useLatestAssetDateAsReleaseDate": "Use latest asset upload as release date",
     "removeAppQuestion": {
         "one": "Usunąć aplikację?",
         "few": "Usunąć aplikacje?",

--- a/assets/translations/pt.json
+++ b/assets/translations/pt.json
@@ -291,6 +291,7 @@
     "shizukuBinderNotFound": "Shizuku não está rodando",
     "useVersionCodeAsOSVersion": "Use app versionCode as OS-detected version",
     "requestHeader": "Request header",
+    "useLatestAssetDateAsReleaseDate": "Use latest asset upload as release date",
     "removeAppQuestion": {
         "one": "Remover aplicativo?",
         "other": "Remover aplicativos?"

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -293,6 +293,7 @@
     "systemFontError": "Ошибка загрузки системного шрифта: {}",
     "useVersionCodeAsOSVersion": "Use app versionCode as OS-detected version",
     "requestHeader": "Request header",
+    "useLatestAssetDateAsReleaseDate": "Use latest asset upload as release date",
     "removeAppQuestion": {
         "one": "Удалить приложение?",
         "other": "Удалить приложения?"

--- a/assets/translations/sv.json
+++ b/assets/translations/sv.json
@@ -277,6 +277,7 @@
     "shizukuBinderNotFound": "Shizuku is not running",
     "useVersionCodeAsOSVersion": "Use app versionCode as OS-detected version",
     "requestHeader": "Request header",
+    "useLatestAssetDateAsReleaseDate": "Use latest asset upload as release date",
     "removeAppQuestion": {
         "one": "Ta Bort App?",
         "other": "Ta Bort Appar?"

--- a/assets/translations/tr.json
+++ b/assets/translations/tr.json
@@ -291,6 +291,7 @@
     "shizukuBinderNotFound": "Shizuku is not running",
     "useVersionCodeAsOSVersion": "Use app versionCode as OS-detected version",
     "requestHeader": "Request header",
+    "useLatestAssetDateAsReleaseDate": "Use latest asset upload as release date",
     "removeAppQuestion": {
         "one": "Uygulamayı Kaldır?",
         "other": "Uygulamaları Kaldır?"

--- a/assets/translations/vi.json
+++ b/assets/translations/vi.json
@@ -289,6 +289,7 @@
     "shizuku": "Shizuku",
     "root": "Root",
     "shizukuBinderNotFound": "Shizuku chưa khởi động",
+    "useLatestAssetDateAsReleaseDate": "Use latest asset upload as release date",
     "removeAppQuestion":{
         "one": "Gỡ ứng dụng?",
         "other": "Gỡ ứng dụng?"

--- a/assets/translations/zh.json
+++ b/assets/translations/zh.json
@@ -293,6 +293,7 @@
     "systemFontError": "加载系统字体出错：{}",
     "useVersionCodeAsOSVersion": "Use app versionCode as OS-detected version",
     "requestHeader": "Request header",
+    "useLatestAssetDateAsReleaseDate": "Use latest asset upload as release date",
     "removeAppQuestion": {
         "one": "是否删除应用？",
         "other": "是否删除应用？"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:obtainium/providers/apps_provider.dart';
 import 'package:obtainium/providers/logs_provider.dart';
 import 'package:obtainium/providers/notifications_provider.dart';
 import 'package:obtainium/providers/settings_provider.dart';
+import 'package:obtainium/providers/source_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 import 'package:dynamic_color/dynamic_color.dart';
@@ -17,10 +18,6 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:easy_localization/src/easy_localization_controller.dart';
 // ignore: implementation_imports
 import 'package:easy_localization/src/localization.dart';
-
-const String currentVersion = '0.15.11';
-const String currentReleaseTag =
-    'v$currentVersion-beta'; // KEEP THIS IN SYNC WITH GITHUB RELEASES
 
 List<MapEntry<Locale, String>> supportedLocales = const [
   MapEntry(Locale('en'), 'English'),
@@ -174,7 +171,29 @@ class _ObtainiumState extends State<Obtainium> {
         // If this is the first run, ask for notification permissions and add Obtainium to the Apps list
         Permission.notification.request();
         if (!fdroid) {
-          appsProvider.saveApps([obtainiumApp], onlyIfExists: false);
+          getInstalledInfo(obtainiumId).then((value) {
+            if (value?.versionName != null) {
+              appsProvider.saveApps([
+                App(
+                    obtainiumId,
+                    obtainiumUrl,
+                    'ImranR98',
+                    'Obtainium',
+                    value!.versionName,
+                    value.versionName!,
+                    [],
+                    0,
+                    {
+                      'includePrereleases': true,
+                      'versionDetection': 'standardVersionDetection'
+                    },
+                    null,
+                    false)
+              ], onlyIfExists: false);
+            }
+          }).catchError((err) {
+            print(err);
+          });
         }
       }
       if (!supportedLocales

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -143,6 +143,7 @@ class _ObtainiumState extends State<Obtainium> {
         BackgroundFetchConfig(
             minimumFetchInterval: 15,
             stopOnTerminate: false,
+            startOnBoot: true,
             enableHeadless: true,
             requiresBatteryNotLow: false,
             requiresCharging: false,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,7 +18,7 @@ import 'package:easy_localization/src/easy_localization_controller.dart';
 // ignore: implementation_imports
 import 'package:easy_localization/src/localization.dart';
 
-const String currentVersion = '0.15.10';
+const String currentVersion = '0.15.11';
 const String currentReleaseTag =
     'v$currentVersion-beta'; // KEEP THIS IN SYNC WITH GITHUB RELEASES
 

--- a/lib/pages/apps.dart
+++ b/lib/pages/apps.dart
@@ -904,7 +904,7 @@ class AppsPageState extends State<AppsPage> {
                                       }))}">${a.name}</a></li>\n';
                                 }
                                 urls +=
-                                    '</ul>\n\n<p><a href="${obtainiumApp.url}">${tr('about')}</a></p>';
+                                    '</ul>\n\n<p><a href="$obtainiumUrl">${tr('about')}</a></p>';
                                 Share.share(urls,
                                     subject:
                                         '${tr('obtainium')} - ${tr('appsString')}');

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -15,22 +15,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:shared_storage/shared_storage.dart' as saf;
 
 String obtainiumTempId = 'imranr98_obtainium_${GitHub().hosts[0]}';
-
-App obtainiumApp = App(
-    'dev.imranr.obtainium',
-    'https://github.com/ImranR98/Obtainium',
-    'ImranR98',
-    'Obtainium',
-    currentReleaseTag,
-    currentReleaseTag,
-    [],
-    0,
-    {
-      'includePrereleases': true,
-      'versionDetection': 'standardVersionDetection'
-    },
-    null,
-    false);
+String obtainiumId = 'dev.imranr.obtainium';
+String obtainiumUrl = 'https://github.com/ImranR98/Obtainium';
 
 enum InstallMethodSettings { normal, shizuku, root }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.15.10+246 # When changing this, update the tag in main() accordingly
+version: 0.15.11+247 # When changing this, update the tag in main() accordingly
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
- Improve loading time (parallelize version detection)
- Newest asset upload date as release date for GitHub (#1284)
- Enable 'start on boot' for BG task (#1234)
- Remove the need to hardcode Obtainium's version number
