### PR TITLE
Bugfix: don't show 'Apps Updated' toast when nothing was updated (#1307), Disable app page buttons while app info is being updated

### DIFF
--- a/lib/pages/app.dart
+++ b/lib/pages/app.dart
@@ -361,7 +361,7 @@ class _AppPageState extends State<AppPage> {
                     app?.app.id != null ? [app!.app.id] : [],
                     globalNavigatorKey.currentContext,
                   );
-                  if (app?.app.installedVersion != null && !trackOnly) {
+                  if (res.isNotEmpty && !trackOnly) {
                     // ignore: use_build_context_synchronously
                     showMessage(tr('appsUpdated'), context);
                   }

--- a/lib/pages/apps.dart
+++ b/lib/pages/apps.dart
@@ -696,7 +696,7 @@ class AppsPageState extends State<AppsPage> {
                     showError(e, context);
                     return <String>[];
                   }).then((value) {
-                    if (shouldInstallUpdates) {
+                    if (value.isNotEmpty && shouldInstallUpdates) {
                       showMessage(tr('appsUpdated'), context);
                     }
                   });


### PR DESCRIPTION
- Bugfix: don't show 'Apps Updated' toast when nothing was updated (#1307)
- Disable app page buttons while app info is being updated