### PR TITLE
Allow existing '/refs' in SourceHut URLs (#1347), Revert to showing App URL separately again (#1336), F-Droid: Don't pull changelog text if it isn't a raw file from GitHub/GitLab (#1340), Add a note on self-hosted instances of sources (#1342), versionCode changes

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -108,3 +108,16 @@ dependencies {
 
     implementation "com.github.topjohnwu.libsu:core:5.2.2"
 }
+
+ext.abiCodes = ["x86_64": 1, "armeabi-v7a": 2, "arm64-v8a": 3]
+import com.android.build.OutputFile
+android.applicationVariants.all { variant ->
+    variant.outputs.each { output ->
+        def abiVersionCode = project.ext.abiCodes.get(output.getFilter(OutputFile.ABI))
+        if (abiVersionCode != null) {
+            output.versionCodeOverride = variant.versionCode * 10 + abiVersionCode
+        } else {
+            output.versionCodeOverride = variant.versionCode * 10
+        }
+    }
+}

--- a/assets/translations/bs.json
+++ b/assets/translations/bs.json
@@ -298,6 +298,8 @@
     "installed": "Instalirano",
     "latest": "Najnoviji",
     "invertRegEx": "Obrni regularni izraz",
+    "note": "Note",
+    "selfHostedNote": "The \"{}\" dropdown can be used to reach self-hosted/custom instances of any source.",
     "removeAppQuestion": {
         "one": "Želite li ukloniti aplikaciju?",
         "other": "Želite li ukloniti aplikacije?"

--- a/assets/translations/cs.json
+++ b/assets/translations/cs.json
@@ -298,6 +298,8 @@
     "installed": "Instalováno",
     "latest": "Nejnovější",
     "invertRegEx": "Invertovat regulární výraz",
+    "note": "Note",
+    "selfHostedNote": "The \"{}\" dropdown can be used to reach self-hosted/custom instances of any source.",
     "removeAppQuestion": {
         "one": "Odstranit Apku?",
         "other": "Odstranit Apky?"

--- a/assets/translations/de.json
+++ b/assets/translations/de.json
@@ -298,6 +298,8 @@
     "installed": "Installiert",
     "latest": "Neueste(r)",
     "invertRegEx": "Regulären Ausdruck  invertieren",
+    "note": "Note",
+    "selfHostedNote": "The \"{}\" dropdown can be used to reach self-hosted/custom instances of any source.",
     "removeAppQuestion": {
         "one": "App entfernen?",
         "other": "Apps entfernen?"

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -298,6 +298,8 @@
     "installed": "Installed",
     "latest": "Latest",
     "invertRegEx": "Invert regular expression",
+    "note": "Note",
+    "selfHostedNote": "The \"{}\" dropdown can be used to reach self-hosted/custom instances of any source.",
     "removeAppQuestion": {
         "one": "Remove App?",
         "other": "Remove Apps?"

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -298,6 +298,8 @@
     "installed": "Instalado",
     "latest": "Versión más reciente",
     "invertRegEx": "Invertir expresión regular",
+    "note": "Note",
+    "selfHostedNote": "The \"{}\" dropdown can be used to reach self-hosted/custom instances of any source.",
     "removeAppQuestion": {
         "one": "¿Eliminar Aplicación?",
         "other": "¿Eliminar Aplicaciones?"

--- a/assets/translations/fa.json
+++ b/assets/translations/fa.json
@@ -298,6 +298,8 @@
     "installed": "نصب شده است",
     "latest": "آخرین",
     "invertRegEx": "معکوس کردن عبارت منظم",
+    "note": "Note",
+    "selfHostedNote": "The \"{}\" dropdown can be used to reach self-hosted/custom instances of any source.",
     "removeAppQuestion": {
         "one": "برنامه حذف شود؟",
         "other": "برنامه ها حذف شوند؟"

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -298,6 +298,8 @@
     "installed": "Installée",
     "latest": "Dernier",
     "invertRegEx": "Inverser l'expression régulière",
+    "note": "Note",
+    "selfHostedNote": "The \"{}\" dropdown can be used to reach self-hosted/custom instances of any source.",
     "removeAppQuestion": {
         "one": "Supprimer l'application ?",
         "other": "Supprimer les applications ?"

--- a/assets/translations/hu.json
+++ b/assets/translations/hu.json
@@ -298,6 +298,8 @@
     "installed": "Telepített",
     "latest": "Legújabb",
     "invertRegEx": "Invertált reguláris kifejezés",
+    "note": "Note",
+    "selfHostedNote": "The \"{}\" dropdown can be used to reach self-hosted/custom instances of any source.",
     "removeAppQuestion": {
         "one": "Eltávolítja az alkalmazást?",
         "other": "Eltávolítja az alkalmazást?"

--- a/assets/translations/it.json
+++ b/assets/translations/it.json
@@ -298,6 +298,8 @@
     "installed": "Installato",
     "latest": "Ultimo",
     "invertRegEx": "Inverti espressione regolare",
+    "note": "Note",
+    "selfHostedNote": "The \"{}\" dropdown can be used to reach self-hosted/custom instances of any source.",
     "removeAppQuestion": {
         "one": "Rimuovere l'app?",
         "other": "Rimuovere le app?"

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -298,6 +298,8 @@
     "installed": "インストール済み",
     "latest": "最新",
     "invertRegEx": "正規表現を反転",
+    "note": "Note",
+    "selfHostedNote": "The \"{}\" dropdown can be used to reach self-hosted/custom instances of any source.",
     "removeAppQuestion": {
         "one": "アプリを削除しますか？",
         "other": "アプリを削除しますか？"

--- a/assets/translations/nl.json
+++ b/assets/translations/nl.json
@@ -298,6 +298,8 @@
     "installed": "Geïnstalleerd",
     "latest": "Laatste",
     "invertRegEx": "Reguliere expressie omkeren",
+    "note": "Note",
+    "selfHostedNote": "The \"{}\" dropdown can be used to reach self-hosted/custom instances of any source.",
     "removeAppQuestion": {
         "one": "App verwijderen?",
         "other": "Apps verwijderen?"

--- a/assets/translations/pl.json
+++ b/assets/translations/pl.json
@@ -298,6 +298,8 @@
     "installed": "Zainstalowano",
     "latest": "Najnowszy",
     "invertRegEx": "Odwróć wyrażenie regularne",
+    "note": "Note",
+    "selfHostedNote": "The \"{}\" dropdown can be used to reach self-hosted/custom instances of any source.",
     "removeAppQuestion": {
         "one": "Usunąć aplikację?",
         "few": "Usunąć aplikacje?",

--- a/assets/translations/pt.json
+++ b/assets/translations/pt.json
@@ -298,6 +298,8 @@
     "installed": "Instalado",
     "latest": "Mais recente",
     "invertRegEx": "Inverter expressão regular",
+    "note": "Note",
+    "selfHostedNote": "The \"{}\" dropdown can be used to reach self-hosted/custom instances of any source.",
     "removeAppQuestion": {
         "one": "Remover aplicativo?",
         "other": "Remover aplicativos?"

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -298,6 +298,8 @@
     "installed": "Установлен",
     "latest": "Последний",
     "invertRegEx": "Инвертировать регулярное выражение",
+    "note": "Note",
+    "selfHostedNote": "The \"{}\" dropdown can be used to reach self-hosted/custom instances of any source.",
     "removeAppQuestion": {
         "one": "Удалить приложение?",
         "other": "Удалить приложения?"

--- a/assets/translations/sv.json
+++ b/assets/translations/sv.json
@@ -298,6 +298,8 @@
     "installed": "Installerad",
     "latest": "Senast",
     "invertRegEx": "Invertera reguljärt uttryck",
+    "note": "Note",
+    "selfHostedNote": "The \"{}\" dropdown can be used to reach self-hosted/custom instances of any source.",
     "removeAppQuestion": {
         "one": "Ta Bort App?",
         "other": "Ta Bort Appar?"

--- a/assets/translations/tr.json
+++ b/assets/translations/tr.json
@@ -298,6 +298,8 @@
     "installed": "Kurulmuş",
     "latest": "En sonuncu",
     "invertRegEx": "Normal ifadeyi ters çevir",
+    "note": "Note",
+    "selfHostedNote": "The \"{}\" dropdown can be used to reach self-hosted/custom instances of any source.",
     "removeAppQuestion": {
         "one": "Uygulamayı Kaldır?",
         "other": "Uygulamaları Kaldır?"

--- a/assets/translations/vi.json
+++ b/assets/translations/vi.json
@@ -298,6 +298,8 @@
     "installed": "Cài đặt",
     "latest": "Mới nhất",
     "invertRegEx": "Đảo ngược biểu thức chính quy",
+    "note": "Note",
+    "selfHostedNote": "The \"{}\" dropdown can be used to reach self-hosted/custom instances of any source.",
     "removeAppQuestion": {
         "one": "Gỡ ứng dụng?",
         "other": "Gỡ ứng dụng?"

--- a/assets/translations/zh.json
+++ b/assets/translations/zh.json
@@ -298,6 +298,8 @@
     "installed": "已安装",
     "latest": "最新的",
     "invertRegEx": "反转正则表达式",
+    "note": "Note",
+    "selfHostedNote": "The \"{}\" dropdown can be used to reach self-hosted/custom instances of any source.",
     "removeAppQuestion": {
         "one": "是否删除应用？",
         "other": "是否删除应用？"

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ if [ -z "$1" ]; then
     git fetch && git merge origin/main && git push # Typically run after a PR to main, so bring dev up to date
 fi
 cd .flutter
+git fetch
 git checkout "$(flutter --version | head -2 | tail -1 | awk '{print $4}')" # Ensure included Flutter submodule version equals my environment
 cd ..
 rm ./build/app/outputs/flutter-apk/* 2>/dev/null                                       # Get rid of older builds if any

--- a/lib/app_sources/sourcehut.dart
+++ b/lib/app_sources/sourcehut.dart
@@ -39,6 +39,15 @@ class SourceHut extends AppSource {
     String standardUrl,
     Map<String, dynamic> additionalSettings,
   ) async {
+    if (standardUrl.endsWith('/refs')) {
+      standardUrl = standardUrl
+          .split('/')
+          .reversed
+          .toList()
+          .sublist(1)
+          .reversed
+          .join('/');
+    }
     Uri standardUri = Uri.parse(standardUrl);
     String appName = standardUri.pathSegments.last;
     bool fallbackToOlderReleases =

--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -530,7 +530,20 @@ class AddAppPageState extends State<AddAppPage> {
                                                 ? TextDecoration.underline
                                                 : TextDecoration.none),
                                       ))),
-                            )
+                            ),
+                            const SizedBox(
+                              height: 16,
+                            ),
+                            Text(
+                              '${tr('note')}:',
+                              style:
+                                  const TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            const SizedBox(
+                              height: 4,
+                            ),
+                            Text(tr('selfHostedNote',
+                                args: [tr('overrideSource')])),
                           ],
                         );
                       },

--- a/lib/pages/app.dart
+++ b/lib/pages/app.dart
@@ -205,6 +205,12 @@ class _AppPageState extends State<AppPage> {
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.displayLarge,
             ),
+            Text(tr('byX', args: [app?.app.author ?? tr('unknown')]),
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.headlineMedium),
+            const SizedBox(
+              height: 24,
+            ),
             GestureDetector(
                 onTap: () {
                   if (app?.app.url != null) {
@@ -219,15 +225,12 @@ class _AppPageState extends State<AppPage> {
                   ));
                 },
                 child: Text(
-                  tr('byX', args: [app?.app.author ?? tr('unknown')]),
+                  app?.app.url ?? '',
                   textAlign: TextAlign.center,
-                  style: Theme.of(context).textTheme.headlineMedium!.copyWith(
+                  style: Theme.of(context).textTheme.labelSmall!.copyWith(
                       decoration: TextDecoration.underline,
                       fontStyle: FontStyle.italic),
                 )),
-            const SizedBox(
-              height: 8,
-            ),
             Text(
               app?.app.id ?? '',
               textAlign: TextAlign.center,

--- a/lib/pages/apps.dart
+++ b/lib/pages/apps.dart
@@ -358,6 +358,16 @@ class AppsPageState extends State<AppsPage> {
       String? changesUrl =
           appSource.changeLogPageFromStandardUrl(listedApps[appIndex].app.url);
       String? changeLog = listedApps[appIndex].app.changeLog;
+      if (changeLog?.split('\n').length == 1) {
+        if (RegExp(
+                '(http|ftp|https)://([\\w_-]+(?:(?:\\.[\\w_-]+)+))([\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~+#-])?')
+            .hasMatch(changeLog!)) {
+          if (changesUrl == null) {
+            changesUrl = changeLog;
+            changeLog = null;
+          }
+        }
+      }
       return (changeLog == null && changesUrl == null)
           ? null
           : () {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -751,18 +751,18 @@ packages:
     dependency: "direct main"
     description:
       name: sqflite
-      sha256: c2c32eb0c74021d987336522acc3b6bf0082fbd0c540c36a9cf4ddb8ba891ddc
+      sha256: a9016f495c927cb90557c909ff26a6d92d9bd54fc42ba92e19d4e79d61e798c6
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: bb4738f15b23352822f4c42a531677e5c6f522e079461fd240ead29d8d8a54a6
+      sha256: "28d8c66baee4968519fb8bd6cdbedad982d6e53359091f0b74544a9f32ec72d5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0+2"
+    version: "2.5.3"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+250 # When changing this, update the tag in main() accordingly
+version: 1.0.1+251 # When changing this, update the tag in main() accordingly
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
- Allow existing '/refs' in SourceHut URLs (#1347)
- Revert to showing App URL separately again (#1336)
- F-Droid: Don't pull changelog text if it isn't a raw file from GitHub/GitLab (#1340)
- Add a note on self-hosted instances of sources (#1342)
- versionCode changes