### PR TITLE
Add support for navbar color change on SDK 28

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -94,7 +94,7 @@ void main() async {
     // Already added, do nothing (see #375)
   }
   await EasyLocalization.ensureInitialized();
-  if ((await DeviceInfoPlugin().androidInfo).version.sdkInt >= 29) {
+  if ((await DeviceInfoPlugin().androidInfo).version.sdkInt >= 28) {
     SystemChrome.setSystemUIOverlayStyle(
       const SystemUiOverlayStyle(systemNavigationBarColor: Colors.transparent),
     );


### PR DESCRIPTION
Since some Android overlays (like Samsung One UI 1.0 with Android 9) are supporting dark theme system-wide, the minimum SDK for navigation bar control was changed from 29 to 28. I think this change should not restrict stock Android 9 users (or with some other overlay) from use.