### PR TITLE
Solve issues with gitlab .apk files and cloudflare protection

### DIFF
--- a/lib/app_sources/gitlab.dart
+++ b/lib/app_sources/gitlab.dart
@@ -112,7 +112,7 @@ class GitLab extends AppSource {
     // Change headers to pacify, e.g. cloudflare protection
     // Related to: (#1397, #1389, #1384, #1382, #1381, #1380, #1359, #854, #785, #697)
     var headers = <String, String>{};
-    headers[HttpHeaders.refererHeader] = 'https://gitlab.com';
+    headers[HttpHeaders.refererHeader] = 'https://${hosts[0]}';
     if (headers.isNotEmpty) {
       return headers;
     } else {

--- a/lib/app_sources/gitlab.dart
+++ b/lib/app_sources/gitlab.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:html/parser.dart';
@@ -103,6 +104,21 @@ class GitLab extends AppSource {
   @override
   String? changeLogPageFromStandardUrl(String standardUrl) =>
       '$standardUrl/-/releases';
+
+  @override
+  Future<Map<String, String>?> getRequestHeaders(
+      Map<String, dynamic> additionalSettings,
+      {bool forAPKDownload = false}) async {
+    // Change headers to pacify, e.g. cloudflare protection
+    // Related to: (#1397, #1389, #1384, #1382, #1381, #1380, #1359, #854, #785, #697)
+    var headers = <String, String>{};
+    headers[HttpHeaders.refererHeader] = 'https://gitlab.com';
+    if (headers.isNotEmpty) {
+      return headers;
+    } else {
+      return null;
+    }
+  }
 
   @override
   Future<APKDetails> getLatestAPKDetails(


### PR DESCRIPTION
There occur issues if releases refer to external hosted .apk files. In some cases (e.g. Aurora Store) download is not possible because cloudflare protection gives "forbidden" error. This patch will add a "referer" header to the download request to pacify cloudflare protection service. 

Notice: In case of the `Aurora Store` project, you still need a `Gitlab API token`, to retrieve latest .apk release. Obtainium either retrieves .apk data from Gitlab API (token necessary) or from `tags`-page, which has no information about the latest .apk url.

Related to: #1397, #1389, #1384, #1382, #1381, #1380, #1359, #854, #785, #697

Tested with Android 14 in an emulated AVD.