### PR TITLE
[discussion] Rework Gitlab .apk retrieval strategies

### DIFF
--- a/lib/app_sources/gitlab.dart
+++ b/lib/app_sources/gitlab.dart
@@ -20,28 +20,28 @@ abstract class RetrievalStrategy {
 class GitlabApiStrategy extends RetrievalStrategy {
 
   // Source context
-  AppSource source;
+  GitLab source;
 
   // Specific source parameters
   String standardUrl;
   Map<String, dynamic> additionalSettings;
 
-  // Specific strategy parameters
-  String privateAccessToken;
-
   /// Constructor with mandatory parameters
-  GitlabApiStrategy(this.source, this.standardUrl, this.additionalSettings, this.privateAccessToken);
+  GitlabApiStrategy(this.source, this.standardUrl, this.additionalSettings);
 
   /// Retrieves an iterable list of ApkDetails
   @override
   Future<Iterable<APKDetails>> retrieve() async {
+
+    // Load Private Access Token
+    String? PAT = await source.getPATIfAny(source.hostChanged ? additionalSettings : {});
 
     // Extract names from URL
     var names = GitHub().getAppNames(standardUrl);
 
     // Request "releases" data from API
     Response res = await source.sourceRequest(
-        'https://${source.hosts[0]}/api/v4/projects/${names.author}%2F${names.name}/releases?private_token=$privateAccessToken',
+        'https://${source.hosts[0]}/api/v4/projects/${names.author}%2F${names.name}/releases?private_token=$PAT',
         additionalSettings);
 
     // Check for HTTP errors
@@ -100,7 +100,7 @@ class GitlabApiStrategy extends RetrievalStrategy {
 class GitlabTagsPageStrategy extends RetrievalStrategy {
 
   // Source context
-  AppSource source;
+  GitLab source;
 
   // Specific source parameters
   String standardUrl;
@@ -291,7 +291,7 @@ class GitLab extends AppSource {
     if (PAT != null) {
 
       // Retrieve from Gitlab API
-      GitlabApiStrategy apiStrategy = GitlabApiStrategy(this, standardUrl, additionalSettings, PAT);
+      GitlabApiStrategy apiStrategy = GitlabApiStrategy(this, standardUrl, additionalSettings);
       apkDetailsList = await apiStrategy.retrieve();
 
     } else {

--- a/lib/app_sources/gitlab.dart
+++ b/lib/app_sources/gitlab.dart
@@ -11,8 +11,13 @@ import 'package:obtainium/components/generated_form.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
+/// This class is designed as an interface to define a .apk retrieval method
+abstract class RetrievalStrategy {
+  Future<Iterable<APKDetails>> retrieve();
+}
+
 /// This class is defined to retrieve .apk-details from gitlab API
-class GitlabApiStrategy {
+class GitlabApiStrategy extends RetrievalStrategy {
 
   // Source context
   AppSource source;
@@ -28,6 +33,7 @@ class GitlabApiStrategy {
   GitlabApiStrategy(this.source, this.standardUrl, this.additionalSettings, this.privateAccessToken);
 
   /// Retrieves an iterable list of ApkDetails
+  @override
   Future<Iterable<APKDetails>> retrieve() async {
 
     // Extract names from URL
@@ -91,7 +97,7 @@ class GitlabApiStrategy {
 }
 
 /// This class is designed to retrieve .apk-details from gitlab's tags-page
-class GitlabTagsPageStrategy {
+class GitlabTagsPageStrategy extends RetrievalStrategy {
 
   // Source context
   AppSource source;
@@ -104,6 +110,7 @@ class GitlabTagsPageStrategy {
   GitlabTagsPageStrategy(this.source, this.standardUrl, this.additionalSettings);
 
   /// Retrieves an iterable list of ApkDetails
+  @override
   Future<Iterable<APKDetails>> retrieve() async {
 
     // Request XML data from gitlab's tags-page

--- a/lib/app_sources/gitlab.dart
+++ b/lib/app_sources/gitlab.dart
@@ -21,18 +21,21 @@ class GitlabApiStrategy {
   String standardUrl;
   Map<String, dynamic> additionalSettings;
 
+  // Specific strategy parameters
+  String privateAccessToken;
+
   /// Constructor with mandatory parameters
-  GitlabApiStrategy(this.source, this.standardUrl, this.additionalSettings);
+  GitlabApiStrategy(this.source, this.standardUrl, this.additionalSettings, this.privateAccessToken);
 
   /// Retrieves an iterable list of ApkDetails
-  Future<Iterable<APKDetails>> retrieve(PAT) async {
+  Future<Iterable<APKDetails>> retrieve() async {
 
     // Extract names from URL
     var names = GitHub().getAppNames(standardUrl);
 
     // Request "releases" data from API
     Response res = await source.sourceRequest(
-        'https://${source.hosts[0]}/api/v4/projects/${names.author}%2F${names.name}/releases?private_token=$PAT',
+        'https://${source.hosts[0]}/api/v4/projects/${names.author}%2F${names.name}/releases?private_token=$privateAccessToken',
         additionalSettings);
 
     // Check for HTTP errors
@@ -281,8 +284,8 @@ class GitLab extends AppSource {
     if (PAT != null) {
 
       // Retrieve from Gitlab API
-      GitlabApiStrategy apiStrategy = GitlabApiStrategy(this, standardUrl, additionalSettings);
-      apkDetailsList = await apiStrategy.retrieve(PAT);
+      GitlabApiStrategy apiStrategy = GitlabApiStrategy(this, standardUrl, additionalSettings, PAT);
+      apkDetailsList = await apiStrategy.retrieve();
 
     } else {
 


### PR DESCRIPTION
`Obtainium 1.0.3` has two strategies to retrieve .apk information from Gitlab: This is either (a) by using the `Gitlab API` with a Private Access Token (PAT) or either (b) by using the `tags`-page of a repository. In some cases (e.g. Aurora Store) the `tags`-page does not have information about related .apk files, but the `Gitlab API` has (#1381, #1380, #697).

This patch will rework the strategy composition (a, b) and provide an interface to add other retrieval strategies, for example (c) scraping the `releases`-page of a repository. 

So the goal of this patch is to retrieve consistent .apk information with every retrieval strategy (API, tags-page, etc.) and in its consequence to make the `Gitlab API Token` superfluous in case of public repositories. Not every Obtainium user might have a Gitlab account to create a Private Access Token (PAT).