### PR TITLE
Fix 'F-Droid' translation' in fr.json

### DIFF
--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -167,7 +167,7 @@
     "lastUpdateCheckX": "Vérification de la dernière mise à jour : {}",
     "remove": "Retirer",
     "yesMarkUpdated": "Oui, marquer comme mis à jour",
-    "fdroid": "F-Droïde Officiel",
+    "fdroid": "F-Droid Officiel",
     "appIdOrName": "ID ou nom de l'application",
     "appId": "ID de l'application",
     "appWithIdOrNameNotFound": "Aucune application n'a été trouvée avec cet identifiant ou ce nom",


### PR DESCRIPTION
There's no "`e`" in the word "F-Droid" in French. Also, there's no "`ï`" in that word. F-Droid is not a translatable name, since it's just a software/product name. 