### PR TITLE
Improve gitlab .apk retrieval (#1450, #1381, #1380)

### DIFF
--- a/lib/app_sources/gitlab.dart
+++ b/lib/app_sources/gitlab.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:html/parser.dart';
 import 'package:http/http.dart';
 import 'package:obtainium/app_sources/github.dart';
 import 'package:obtainium/custom_errors.dart';

--- a/lib/app_sources/gitlab.dart
+++ b/lib/app_sources/gitlab.dart
@@ -113,84 +113,43 @@ class GitLab extends AppSource {
         additionalSettings['fallbackToOlderReleases'] == true;
     String? PAT = await getPATIfAny(hostChanged ? additionalSettings : {});
     Iterable<APKDetails> apkDetailsList = [];
-    if (PAT != null) {
-      var names = GitHub().getAppNames(standardUrl);
-      Response res = await sourceRequest(
-          'https://${hosts[0]}/api/v4/projects/${names.author}%2F${names.name}/releases?private_token=$PAT',
-          additionalSettings);
-      if (res.statusCode != 200) {
-        throw getObtainiumHttpError(res);
-      }
-      var json = jsonDecode(res.body) as List<dynamic>;
-      apkDetailsList = json.map((e) {
-        var apkUrlsFromAssets = (e['assets']?['links'] as List<dynamic>? ?? [])
-            .map((e) {
-              return (e['direct_asset_url'] ?? e['url'] ?? '') as String;
-            })
-            .where((s) => s.isNotEmpty)
-            .toList();
-        List<String> uploadedAPKsFromDescription =
-            ((e['description'] ?? '') as String)
-                .split('](')
-                .join('\n')
-                .split('.apk)')
-                .join('.apk\n')
-                .split('\n')
-                .where((s) => s.startsWith('/uploads/') && s.endsWith('apk'))
-                .map((s) => '$standardUrl$s')
-                .toList();
-        var apkUrlsSet = apkUrlsFromAssets.toSet();
-        apkUrlsSet.addAll(uploadedAPKsFromDescription);
-        var releaseDateString = e['released_at'] ?? e['created_at'];
-        DateTime? releaseDate = releaseDateString != null
-            ? DateTime.parse(releaseDateString)
-            : null;
-        return APKDetails(
-            e['tag_name'] ?? e['name'],
-            getApkUrlsFromUrls(apkUrlsSet.toList()),
-            GitHub().getAppNames(standardUrl),
-            releaseDate: releaseDate);
-      });
-    } else {
-      Response res = await sourceRequest(
-          '$standardUrl/-/tags?format=atom', additionalSettings);
-      if (res.statusCode != 200) {
-        throw getObtainiumHttpError(res);
-      }
-      var standardUri = Uri.parse(standardUrl);
-      var parsedHtml = parse(res.body);
-      apkDetailsList = parsedHtml.querySelectorAll('entry').map((entry) {
-        var entryContent = parse(
-            parseFragment(entry.querySelector('content')!.innerHtml).text);
-        var apkUrls = [
-          ...getLinksFromParsedHTML(
-              entryContent,
-              RegExp(
-                  '^${standardUri.path.replaceAllMapped(RegExp(r'[.*+?^${}()|[\]\\]'), (x) {
-                    return '\\${x[0]}';
-                  })}/uploads/[^/]+/[^/]+\\.apk\$',
-                  caseSensitive: false),
-              standardUri.origin),
-          // GitLab releases may contain links to externally hosted APKs
-          ...getLinksFromParsedHTML(entryContent,
-                  RegExp('/[^/]+\\.apk\$', caseSensitive: false), '')
-              .where((element) => Uri.parse(element).host != '')
-        ];
-        var entryId = entry.querySelector('id')?.innerHtml;
-        var version =
-            entryId == null ? null : Uri.parse(entryId).pathSegments.last;
-        var releaseDateString = entry.querySelector('updated')?.innerHtml;
-        DateTime? releaseDate = releaseDateString != null
-            ? DateTime.parse(releaseDateString)
-            : null;
-        if (version == null) {
-          throw NoVersionError();
-        }
-        return APKDetails(version, getApkUrlsFromUrls(apkUrls),
-            GitHub().getAppNames(standardUrl),
-            releaseDate: releaseDate);
-      });
+    var names = GitHub().getAppNames(standardUrl);
+    Response res = await sourceRequest(
+        'https://${hosts[0]}/api/v4/projects/${names.author}%2F${names.name}/releases?private_token=$PAT',
+        additionalSettings);
+    if (res.statusCode != 200) {
+      throw getObtainiumHttpError(res);
     }
+    var json = jsonDecode(res.body) as List<dynamic>;
+    apkDetailsList = json.map((e) {
+      var apkUrlsFromAssets = (e['assets']?['links'] as List<dynamic>? ?? [])
+          .map((e) {
+            return (e['direct_asset_url'] ?? e['url'] ?? '') as String;
+          })
+          .where((s) => s.isNotEmpty)
+          .toList();
+      List<String> uploadedAPKsFromDescription =
+          ((e['description'] ?? '') as String)
+              .split('](')
+              .join('\n')
+              .split('.apk)')
+              .join('.apk\n')
+              .split('\n')
+              .where((s) => s.startsWith('/uploads/') && s.endsWith('apk'))
+              .map((s) => '$standardUrl$s')
+              .toList();
+      var apkUrlsSet = apkUrlsFromAssets.toSet();
+      apkUrlsSet.addAll(uploadedAPKsFromDescription);
+      var releaseDateString = e['released_at'] ?? e['created_at'];
+      DateTime? releaseDate = releaseDateString != null
+          ? DateTime.parse(releaseDateString)
+          : null;
+      return APKDetails(
+          e['tag_name'] ?? e['name'],
+          getApkUrlsFromUrls(apkUrlsSet.toList()),
+          GitHub().getAppNames(standardUrl),
+          releaseDate: releaseDate);
+    });
     if (apkDetailsList.isEmpty) {
       throw NoReleasesError(note: tr('gitlabSourceNote'));
     }

--- a/lib/app_sources/gitlab.dart
+++ b/lib/app_sources/gitlab.dart
@@ -112,10 +112,11 @@ class GitLab extends AppSource {
     // Prepare request params
     var names = GitHub().getAppNames(standardUrl);
     String? PAT = await getPATIfAny(hostChanged ? additionalSettings : {});
+    String optionalAuth = (PAT != null) ? 'private_token=$PAT' : '';
 
     // Request data from REST API
     Response res = await sourceRequest(
-        'https://${hosts[0]}/api/v4/projects/${names.author}%2F${names.name}/releases?private_token=$PAT',
+        'https://${hosts[0]}/api/v4/projects/${names.author}%2F${names.name}/releases?$optionalAuth',
         additionalSettings);
     if (res.statusCode != 200) {
       throw getObtainiumHttpError(res);


### PR DESCRIPTION
Obtainium 1.0.4 has two strategies to retrieve .apk information from Gitlab: This is either (a) by using the Gitlab API with a Private Access Token (PAT) or either (b) by using the tags-page of a repository. In some cases (e.g. Aurora Store) the tags-page does not have information about related .apk files, but the Gitlab API has (#1450, #1381, #1380).

This patch removes the tags-page as an information provider and simplifies the retrieval logic. As it turned out: Gitlab's REST API works without `Private Access Token` authentication for public repositories. So the `Private Access Token` is optional in case authentication is required.

Previous discussion: #1438 

Tested with `Android 14` on an emulated AVD
- [x] _When_ I add AuroraStore with its Gitlab url _Then_ Obtainium shows the latest version correctly _And When_ I click install _Then_ Obtainium installs this version successfully
- [x] _When_ I add AppWarden with its Gitlab url _Then_ Obtainium shows the latest version correctly _And When_ i click install _Then_ Obtainium installs this version successfully

Notice: I haven't tested this patch with private repositories and/or private Gitlab instances yet.