### PR TITLE
Fix out of bounds array access in GeneratedForm update

### DIFF
--- a/lib/components/generated_form.dart
+++ b/lib/components/generated_form.dart
@@ -245,8 +245,8 @@ class _GeneratedFormState extends State<GeneratedForm> {
   void someValueChanged({bool isBuilding = false, bool forceInvalid = false}) {
     Map<String, dynamic> returnValues = values;
     var valid = true;
-    for (int r = 0; r < widget.items.length; r++) {
-      for (int i = 0; i < widget.items[r].length; i++) {
+    for (int r = 0; r < formInputs.length; r++) {
+      for (int i = 0; i < formInputs[r].length; i++) {
         if (formInputs[r][i] is TextFormField) {
           valid = valid && validateTextField(formInputs[r][i] as TextFormField);
         }


### PR DESCRIPTION
Closes https://github.com/ImranR98/Obtainium/issues/1530.

See issue for reproduction. The length of `widget.items` is one item longer than `formInputs`, it was causing a [RangeError](https://github.com/ImranR98/Obtainium/issues/1530#issuecomment-2043493700) when trying to access `formInputs[r]` and `r` was going to to `widget.items.length`:
```
I/flutter ( 1881): widget.items.length: 21
I/flutter ( 1881): formInputs.length: 20
```