### PR TITLE
Use applicationId for provider authorities

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -47,7 +47,7 @@
             android:value="2" />
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="dev.imranr.obtainium"
+            android:authorities="${applicationId}"
             android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"


### PR DESCRIPTION
Fixes #1378

Instead of hardcoding the authority string, use the ${applicationId} to always make the provider unique.