### PR TITLE
Enable per-app language, closes #1430

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:requestLegacyExternalStorage="true"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="true"
+        android:localeConfig="@xml/locales_config">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/xml/locales_config.xml
+++ b/android/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="bs"/>
+    <locale android:name="cs"/>
+    <locale android:name="de"/>
+    <locale android:name="en"/>
+    <locale android:name="es"/>
+    <locale android:name="fa"/>
+    <locale android:name="fr"/>
+    <locale android:name="hu"/>
+    <locale android:name="it"/>
+    <locale android:name="ja"/>
+    <locale android:name="nl"/>
+    <locale android:name="pl"/>
+    <locale android:name="pt"/>
+    <locale android:name="ru"/>
+    <locale android:name="sv"/>
+    <locale android:name="tr"/>
+    <locale android:name="uk"/>
+    <locale android:name="vi"/>
+    <locale android:name="zh"/>
+</locale-config>


### PR DESCRIPTION
Hi!
I've manually enabled per-app langugage as per [android docs](https://developer.android.com/guide/topics/resources/app-languages#use-localeconfig) as flutter does not support it [yet](https://github.com/flutter/flutter/issues/109842)