### PR TITLE
Add "Community App Sources" translation and button to Add App Screen

### DIFF
--- a/assets/translations/bs.json
+++ b/assets/translations/bs.json
@@ -315,9 +315,9 @@
     "appVerifierInstructionToast": "Dijeli sa AppVerifier-om, zatim se vratite kada ste spremni.",
     "wiki": "Pomoć/Wiki",
     "crowdsourcedConfigsLabel": "Konfiguracije aplikacije obezbeđene pomoću velikog broja ljudi (crowdsourcing) (koristite na svoju odgovornost)",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Allow insecure HTTP requests",
     "stayOneVersionBehind": "Stay one version behind latest",
-    "communityAppSources": "Community App Sources",
     "removeAppQuestion": {
         "one": "Želite li ukloniti aplikaciju?",
         "other": "Želite li ukloniti aplikacije?"

--- a/assets/translations/bs.json
+++ b/assets/translations/bs.json
@@ -317,6 +317,7 @@
     "crowdsourcedConfigsLabel": "Konfiguracije aplikacije obezbeđene pomoću velikog broja ljudi (crowdsourcing) (koristite na svoju odgovornost)",
     "allowInsecure": "Allow insecure HTTP requests",
     "stayOneVersionBehind": "Stay one version behind latest",
+    "communityAppSources": "Community App Sources",
     "removeAppQuestion": {
         "one": "Želite li ukloniti aplikaciju?",
         "other": "Želite li ukloniti aplikacije?"

--- a/assets/translations/cs.json
+++ b/assets/translations/cs.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "Sdílejte do aplikace AppVerifier a po dokončení se sem vraťte.",
     "wiki": "Nápověda/Wiki",
     "crowdsourcedConfigsLabel": "Konfigurace aplikací s využitím crowdsourcingu (použití na vlastní nebezpečí)",
+    "communityAppSources": "Komunitní zdroje aplikací",
     "allowInsecure": "Povolení nezabezpečených požadavků HTTP",
     "stayOneVersionBehind": "Zůstaňte o jednu verzi pozadu za nejnovější",
     "removeAppQuestion": {

--- a/assets/translations/cs.json
+++ b/assets/translations/cs.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Sdílejte do aplikace AppVerifier a po dokončení se sem vraťte.",
     "wiki": "Nápověda/Wiki",
     "crowdsourcedConfigsLabel": "Konfigurace aplikací s využitím crowdsourcingu (použití na vlastní nebezpečí)",
-    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
+    "crowdsourcedConfigsShort": "Konfigurace aplikací s využitím crowdsourcingu",
     "allowInsecure": "Povolení nezabezpečených požadavků HTTP",
     "stayOneVersionBehind": "Zůstaňte o jednu verzi pozadu za nejnovější",
     "removeAppQuestion": {

--- a/assets/translations/cs.json
+++ b/assets/translations/cs.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Sdílejte do aplikace AppVerifier a po dokončení se sem vraťte.",
     "wiki": "Nápověda/Wiki",
     "crowdsourcedConfigsLabel": "Konfigurace aplikací s využitím crowdsourcingu (použití na vlastní nebezpečí)",
-    "communityAppSources": "Komunitní zdroje aplikací",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Povolení nezabezpečených požadavků HTTP",
     "stayOneVersionBehind": "Zůstaňte o jednu verzi pozadu za nejnovější",
     "removeAppQuestion": {

--- a/assets/translations/da.json
+++ b/assets/translations/da.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "Del til AppVerifier, og vend tilbage hertil, når du er klar.",
     "wiki": "Hjælp/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsourcede app-konfigurationer (brug på egen risiko)",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Tillad usikre HTTP-anmodninger",
     "stayOneVersionBehind": "Vær en version bagud i forhold til den nyeste",
     "removeAppQuestion": {

--- a/assets/translations/da.json
+++ b/assets/translations/da.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Del til AppVerifier, og vend tilbage hertil, når du er klar.",
     "wiki": "Hjælp/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsourcede app-konfigurationer (brug på egen risiko)",
-    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
+    "crowdsourcedConfigsShort": "Crowdsourcede app-konfigurationer",
     "allowInsecure": "Tillad usikre HTTP-anmodninger",
     "stayOneVersionBehind": "Vær en version bagud i forhold til den nyeste",
     "removeAppQuestion": {

--- a/assets/translations/de.json
+++ b/assets/translations/de.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "Geben Sie die Daten an AppVerifier weiter und kehren Sie dann hierher zurück, wenn Sie fertig sind.",
     "wiki": "Hilfe/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsourced App-Konfigurationen (Verwendung auf eigene Gefahr)",
+    "communityAppSources": "Community-App-Quellen",
     "allowInsecure": "Unsichere HTTP-Anfragen zulassen",
     "stayOneVersionBehind": "Eine Version hinter der neuesten Version bleiben",
     "removeAppQuestion": {

--- a/assets/translations/de.json
+++ b/assets/translations/de.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Geben Sie die Daten an AppVerifier weiter und kehren Sie dann hierher zurück, wenn Sie fertig sind.",
     "wiki": "Hilfe/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsourced App-Konfigurationen (Verwendung auf eigene Gefahr)",
-    "communityAppSources": "Community-App-Quellen",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Unsichere HTTP-Anfragen zulassen",
     "stayOneVersionBehind": "Eine Version hinter der neuesten Version bleiben",
     "removeAppQuestion": {

--- a/assets/translations/de.json
+++ b/assets/translations/de.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Geben Sie die Daten an AppVerifier weiter und kehren Sie dann hierher zurück, wenn Sie fertig sind.",
     "wiki": "Hilfe/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsourced App-Konfigurationen (Verwendung auf eigene Gefahr)",
-    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
+    "crowdsourcedConfigsShort": "Crowdsourced App-Konfigurationen",
     "allowInsecure": "Unsichere HTTP-Anfragen zulassen",
     "stayOneVersionBehind": "Eine Version hinter der neuesten Version bleiben",
     "removeAppQuestion": {

--- a/assets/translations/en-EO.json
+++ b/assets/translations/en-EO.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "Diskonigu kun AppVerifier, poste revenu ĉi tie kiam preta.",
     "wiki": "Helpo/Vikio",
     "crowdsourcedConfigsLabel": "Komunumaj apo-agordoj (uzu kun singardo)",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Allow insecure HTTP requests",
     "stayOneVersionBehind": "Stay one version behind latest",
     "removeAppQuestion": {

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Share to AppVerifier, then return here when ready.",
     "wiki": "Help/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsourced App Configurations (use at your own risk)",
-    "communityAppSources": "Community App Sources",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Allow insecure HTTP requests",
     "stayOneVersionBehind": "Stay one version behind latest",
     "removeAppQuestion": {

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "Share to AppVerifier, then return here when ready.",
     "wiki": "Help/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsourced App Configurations (use at your own risk)",
+    "communityAppSources": "Community App Sources",
     "allowInsecure": "Allow insecure HTTP requests",
     "stayOneVersionBehind": "Stay one version behind latest",
     "removeAppQuestion": {

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "Comparta con AppVerifier y vuelva aquí cuando esté listo.",
     "wiki": "Ayuda/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsourced App Configurations (uso bajo su propia responsabilidad)",
+    "communityAppSources": "Fuentes de aplicaciones comunitarias",
     "allowInsecure": "Permitir peticiones HTTP inseguras",
     "stayOneVersionBehind": "Mantenerse una versión por detrás de la última",
     "removeAppQuestion": {

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Comparta con AppVerifier y vuelva aquí cuando esté listo.",
     "wiki": "Ayuda/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsourced App Configurations (uso bajo su propia responsabilidad)",
-    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
+    "crowdsourcedConfigsShort": "Configuración de aplicaciones por crowdsourcing",
     "allowInsecure": "Permitir peticiones HTTP inseguras",
     "stayOneVersionBehind": "Mantenerse una versión por detrás de la última",
     "removeAppQuestion": {

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Comparta con AppVerifier y vuelva aquí cuando esté listo.",
     "wiki": "Ayuda/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsourced App Configurations (uso bajo su propia responsabilidad)",
-    "communityAppSources": "Fuentes de aplicaciones comunitarias",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Permitir peticiones HTTP inseguras",
     "stayOneVersionBehind": "Mantenerse una versión por detrás de la última",
     "removeAppQuestion": {

--- a/assets/translations/fa.json
+++ b/assets/translations/fa.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "در AppVerifier به اشتراک بگذارید، سپس پس از آماده شدن به اینجا برگردید.",
     "wiki": "راهنما/ویکی",
     "crowdsourcedConfigsLabel": "تنظیمات برنامه Crowdsourced (با مسئولیت خود استفاده کنید)",
+    "communityAppSources": "منابع برنامه جامعه",
     "allowInsecure": "درخواست های HTTP ناامن را مجاز کنید",
     "stayOneVersionBehind": "Stay one version behind latest",
     "removeAppQuestion": {

--- a/assets/translations/fa.json
+++ b/assets/translations/fa.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "در AppVerifier به اشتراک بگذارید، سپس پس از آماده شدن به اینجا برگردید.",
     "wiki": "راهنما/ویکی",
     "crowdsourcedConfigsLabel": "تنظیمات برنامه Crowdsourced (با مسئولیت خود استفاده کنید)",
-    "communityAppSources": "منابع برنامه جامعه",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "درخواست های HTTP ناامن را مجاز کنید",
     "stayOneVersionBehind": "Stay one version behind latest",
     "removeAppQuestion": {

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Partagez avec AppVerifier, puis revenez ici lorsque tout est prêt.",
     "wiki": "Aide/Wiki",
     "crowdsourcedConfigsLabel": "Configurations d'applications par la communauté (à utiliser à vos risques et périls)",
-    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
+    "crowdsourcedConfigsShort": "Configurations d'applications par la foule",
     "allowInsecure": "Autoriser les requêtes HTTP non sécurisées",
     "stayOneVersionBehind": "Rester à une version de la dernière",
     "removeAppQuestion": {

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "Partagez avec AppVerifier, puis revenez ici lorsque tout est prêt.",
     "wiki": "Aide/Wiki",
     "crowdsourcedConfigsLabel": "Configurations d'applications par la communauté (à utiliser à vos risques et périls)",
+    "communityAppSources": "Sources d'applications communautaires",
     "allowInsecure": "Autoriser les requêtes HTTP non sécurisées",
     "stayOneVersionBehind": "Rester à une version de la dernière",
     "removeAppQuestion": {

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Partagez avec AppVerifier, puis revenez ici lorsque tout est prêt.",
     "wiki": "Aide/Wiki",
     "crowdsourcedConfigsLabel": "Configurations d'applications par la communauté (à utiliser à vos risques et périls)",
-    "communityAppSources": "Sources d'applications communautaires",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Autoriser les requêtes HTTP non sécurisées",
     "stayOneVersionBehind": "Rester à une version de la dernière",
     "removeAppQuestion": {

--- a/assets/translations/hu.json
+++ b/assets/translations/hu.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Ossza meg az AppVerifierrel, majd térjen vissza ide, ha kész.",
     "wiki": "Súgó/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsource-ből származó alkalmazások beállítása (saját felelősségére használja)",
-    "communityAppSources": "Közösségi alkalmazásforrások",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Nem biztonságos HTTP-kérések engedélyezése",
     "stayOneVersionBehind": "Maradjon egy verzióval a legfrissebb mögött",
     "removeAppQuestion": {

--- a/assets/translations/hu.json
+++ b/assets/translations/hu.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "Ossza meg az AppVerifierrel, majd térjen vissza ide, ha kész.",
     "wiki": "Súgó/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsource-ből származó alkalmazások beállítása (saját felelősségére használja)",
+    "communityAppSources": "Közösségi alkalmazásforrások",
     "allowInsecure": "Nem biztonságos HTTP-kérések engedélyezése",
     "stayOneVersionBehind": "Maradjon egy verzióval a legfrissebb mögött",
     "removeAppQuestion": {

--- a/assets/translations/id.json
+++ b/assets/translations/id.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Bagikan ke AppVerifier, lalu kembali ke sini jika sudah siap.",
     "wiki": "Bantuan/Wiki",
     "crowdsourcedConfigsLabel": "Konfigurasi aplikasi Crowdsourced (risiko penggunaan ditanggung sendiri)",
-    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
+    "crowdsourcedConfigsShort": "Konfigurasi Aplikasi Crowdsourced",
     "allowInsecure": "Izinkan permintaan HTTP yang tidak aman",
     "stayOneVersionBehind": "Tetap satu versi di belakang versi terbaru",
     "removeAppQuestion": {

--- a/assets/translations/id.json
+++ b/assets/translations/id.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "Bagikan ke AppVerifier, lalu kembali ke sini jika sudah siap.",
     "wiki": "Bantuan/Wiki",
     "crowdsourcedConfigsLabel": "Konfigurasi aplikasi Crowdsourced (risiko penggunaan ditanggung sendiri)",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Izinkan permintaan HTTP yang tidak aman",
     "stayOneVersionBehind": "Tetap satu versi di belakang versi terbaru",
     "removeAppQuestion": {

--- a/assets/translations/it.json
+++ b/assets/translations/it.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "Condividete con AppVerifier, quindi tornate qui quando siete pronti.",
     "wiki": "Aiuto/Wiki",
     "crowdsourcedConfigsLabel": "Configurazioni di app in crowdsourcing (uso a proprio rischio)",
+    "communityAppSources": "Fonti di app comunitarie",
     "allowInsecure": "Consentire le richieste HTTP non sicure",
     "stayOneVersionBehind": "Rimanere una versione indietro rispetto alla più recente",
     "removeAppQuestion": {

--- a/assets/translations/it.json
+++ b/assets/translations/it.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Condividete con AppVerifier, quindi tornate qui quando siete pronti.",
     "wiki": "Aiuto/Wiki",
     "crowdsourcedConfigsLabel": "Configurazioni di app in crowdsourcing (uso a proprio rischio)",
-    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
+    "crowdsourcedConfigsShort": "Configurazioni di app in crowdsourcing",
     "allowInsecure": "Consentire le richieste HTTP non sicure",
     "stayOneVersionBehind": "Rimanere una versione indietro rispetto alla più recente",
     "removeAppQuestion": {

--- a/assets/translations/it.json
+++ b/assets/translations/it.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Condividete con AppVerifier, quindi tornate qui quando siete pronti.",
     "wiki": "Aiuto/Wiki",
     "crowdsourcedConfigsLabel": "Configurazioni di app in crowdsourcing (uso a proprio rischio)",
-    "communityAppSources": "Fonti di app comunitarie",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Consentire le richieste HTTP non sicure",
     "stayOneVersionBehind": "Rimanere una versione indietro rispetto alla più recente",
     "removeAppQuestion": {

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "AppVerifierに共有し、準備ができたらここに戻ってください。",
     "wiki": "ヘルプ/ウィキ",
     "crowdsourcedConfigsLabel": "クラウドソーシングによるアプリの設定（利用は自己責任で）",
-    "communityAppSources": "コミュニティのアプリソース",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "安全でないHTTPリクエストを許可する",
     "stayOneVersionBehind": "最新バージョンから1つ遅れ",
     "removeAppQuestion": {

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "AppVerifierに共有し、準備ができたらここに戻ってください。",
     "wiki": "ヘルプ/ウィキ",
     "crowdsourcedConfigsLabel": "クラウドソーシングによるアプリの設定（利用は自己責任で）",
-    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
+    "crowdsourcedConfigsShort": "クラウドソーシングによるアプリの設定",
     "allowInsecure": "安全でないHTTPリクエストを許可する",
     "stayOneVersionBehind": "最新バージョンから1つ遅れ",
     "removeAppQuestion": {

--- a/assets/translations/ja.json
+++ b/assets/translations/ja.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "AppVerifierに共有し、準備ができたらここに戻ってください。",
     "wiki": "ヘルプ/ウィキ",
     "crowdsourcedConfigsLabel": "クラウドソーシングによるアプリの設定（利用は自己責任で）",
+    "communityAppSources": "コミュニティのアプリソース",
     "allowInsecure": "安全でないHTTPリクエストを許可する",
     "stayOneVersionBehind": "最新バージョンから1つ遅れ",
     "removeAppQuestion": {

--- a/assets/translations/nl.json
+++ b/assets/translations/nl.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Deel het met AppVerifier en keer daarna hier terug.",
     "wiki": "Help/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsourced App-configuraties (gebruik op eigen risico)",
-    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
+    "crowdsourcedConfigsShort": "App-configuraties door menigte",
     "allowInsecure": "Onveilige HTTP-verzoeken toestaan",
     "stayOneVersionBehind": "Blijf een versie achter op de nieuwste",
     "removeAppQuestion": {

--- a/assets/translations/nl.json
+++ b/assets/translations/nl.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "Deel het met AppVerifier en keer daarna hier terug.",
     "wiki": "Help/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsourced App-configuraties (gebruik op eigen risico)",
+    "communityAppSources": "Bronnen voor community-apps",
     "allowInsecure": "Onveilige HTTP-verzoeken toestaan",
     "stayOneVersionBehind": "Blijf een versie achter op de nieuwste",
     "removeAppQuestion": {

--- a/assets/translations/nl.json
+++ b/assets/translations/nl.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Deel het met AppVerifier en keer daarna hier terug.",
     "wiki": "Help/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsourced App-configuraties (gebruik op eigen risico)",
-    "communityAppSources": "Bronnen voor community-apps",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Onveilige HTTP-verzoeken toestaan",
     "stayOneVersionBehind": "Blijf een versie achter op de nieuwste",
     "removeAppQuestion": {

--- a/assets/translations/pl.json
+++ b/assets/translations/pl.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "Udostępnij w AppVerifier, a następnie wróć tutaj, gdy będziesz gotowy.",
     "wiki": "Pomoc/Wiki",
     "crowdsourcedConfigsLabel": "Konfiguracje aplikacji pochodzące z crowdsourcingu (korzystanie na własne ryzyko)",
+    "communityAppSources": "Zrodliny aplikacji komunity",
     "allowInsecure": "Zezwalaj na niezabezpieczone żądania HTTP",
     "stayOneVersionBehind": "Pozostań jedną wersję za najnowszą",
     "removeAppQuestion": {

--- a/assets/translations/pl.json
+++ b/assets/translations/pl.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Udostępnij w AppVerifier, a następnie wróć tutaj, gdy będziesz gotowy.",
     "wiki": "Pomoc/Wiki",
     "crowdsourcedConfigsLabel": "Konfiguracje aplikacji pochodzące z crowdsourcingu (korzystanie na własne ryzyko)",
-    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
+    "crowdsourcedConfigsShort": "Konfiguracje aplikacji pochodzące z crowdsourcingu",
     "allowInsecure": "Zezwalaj na niezabezpieczone żądania HTTP",
     "stayOneVersionBehind": "Pozostań jedną wersję za najnowszą",
     "removeAppQuestion": {

--- a/assets/translations/pl.json
+++ b/assets/translations/pl.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Udostępnij w AppVerifier, a następnie wróć tutaj, gdy będziesz gotowy.",
     "wiki": "Pomoc/Wiki",
     "crowdsourcedConfigsLabel": "Konfiguracje aplikacji pochodzące z crowdsourcingu (korzystanie na własne ryzyko)",
-    "communityAppSources": "Zrodliny aplikacji komunity",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Zezwalaj na niezabezpieczone żądania HTTP",
     "stayOneVersionBehind": "Pozostań jedną wersję za najnowszą",
     "removeAppQuestion": {

--- a/assets/translations/pt.json
+++ b/assets/translations/pt.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Partilhe com o AppVerifier e, em seguida, regresse aqui quando estiver pronto.",
     "wiki": "Ajuda/Wiki",
     "crowdsourcedConfigsLabel": "Configurações de aplicações de crowdsourcing (utilização por sua conta e risco)",
-    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
+    "crowdsourcedConfigsShort": "Configurações de aplicações com base em crowdsourcing",
     "allowInsecure": "Permitir pedidos HTTP inseguros",
     "stayOneVersionBehind": "Manter-se uma versão atrás da mais recente",
     "removeAppQuestion": {

--- a/assets/translations/pt.json
+++ b/assets/translations/pt.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "Partilhe com o AppVerifier e, em seguida, regresse aqui quando estiver pronto.",
     "wiki": "Ajuda/Wiki",
     "crowdsourcedConfigsLabel": "Configurações de aplicações de crowdsourcing (utilização por sua conta e risco)",
+    "communityAppSources": "Fontes de aplicações da comunidade",
     "allowInsecure": "Permitir pedidos HTTP inseguros",
     "stayOneVersionBehind": "Manter-se uma versão atrás da mais recente",
     "removeAppQuestion": {

--- a/assets/translations/pt.json
+++ b/assets/translations/pt.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Partilhe com o AppVerifier e, em seguida, regresse aqui quando estiver pronto.",
     "wiki": "Ajuda/Wiki",
     "crowdsourcedConfigsLabel": "Configurações de aplicações de crowdsourcing (utilização por sua conta e risco)",
-    "communityAppSources": "Fontes de aplicações da comunidade",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Permitir pedidos HTTP inseguros",
     "stayOneVersionBehind": "Manter-se uma versão atrás da mais recente",
     "removeAppQuestion": {

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Поделитесь с AppVerifier, а затем вернитесь сюда, когда будете готовы.",
     "wiki": "Помощь/Вики",
     "crowdsourcedConfigsLabel": "Конфигурации приложений на основе краудсорсинга (используйте на свой страх и риск)",
-    "communityAppSources": "Источники приложений сообщества",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Разрешить небезопасные HTTP-запросы",
     "stayOneVersionBehind": "Не отставайте от последней версии",
     "removeAppQuestion": {

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Поделитесь с AppVerifier, а затем вернитесь сюда, когда будете готовы.",
     "wiki": "Помощь/Вики",
     "crowdsourcedConfigsLabel": "Конфигурации приложений на основе краудсорсинга (используйте на свой страх и риск)",
-    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
+    "crowdsourcedConfigsShort": "Конфиги приложений с помощью краудсорсинга",
     "allowInsecure": "Разрешить небезопасные HTTP-запросы",
     "stayOneVersionBehind": "Не отставайте от последней версии",
     "removeAppQuestion": {

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "Поделитесь с AppVerifier, а затем вернитесь сюда, когда будете готовы.",
     "wiki": "Помощь/Вики",
     "crowdsourcedConfigsLabel": "Конфигурации приложений на основе краудсорсинга (используйте на свой страх и риск)",
+    "communityAppSources": "Источники приложений сообщества",
     "allowInsecure": "Разрешить небезопасные HTTP-запросы",
     "stayOneVersionBehind": "Не отставайте от последней версии",
     "removeAppQuestion": {

--- a/assets/translations/sv.json
+++ b/assets/translations/sv.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "Dela till AppVerifier och återvänd sedan hit när du är klar.",
     "wiki": "Hjälp/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsourcade appkonfigurationer (använd på egen risk)",
+    "communityAppSources": "Gemenskapsappresurser",
     "allowInsecure": "Tillåt osäkra HTTP-förfrågningar",
     "stayOneVersionBehind": "Håll dig en version bakom den senaste",
     "removeAppQuestion": {

--- a/assets/translations/sv.json
+++ b/assets/translations/sv.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Dela till AppVerifier och återvänd sedan hit när du är klar.",
     "wiki": "Hjälp/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsourcade appkonfigurationer (använd på egen risk)",
-    "communityAppSources": "Gemenskapsappresurser",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Tillåt osäkra HTTP-förfrågningar",
     "stayOneVersionBehind": "Håll dig en version bakom den senaste",
     "removeAppQuestion": {

--- a/assets/translations/sv.json
+++ b/assets/translations/sv.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Dela till AppVerifier och återvänd sedan hit när du är klar.",
     "wiki": "Hjälp/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsourcade appkonfigurationer (använd på egen risk)",
-    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
+    "crowdsourcedConfigsShort": "Appkonfigurationer med hjälp av crowdsourcing",
     "allowInsecure": "Tillåt osäkra HTTP-förfrågningar",
     "stayOneVersionBehind": "Håll dig en version bakom den senaste",
     "removeAppQuestion": {

--- a/assets/translations/tr.json
+++ b/assets/translations/tr.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "AppVerifier ile paylaşın, hazır olduğunuzda buraya dönün.",
     "wiki": "Yardım/Wiki",
     "crowdsourcedConfigsLabel": "Kitle Kaynaklı Uygulama Yapılandırmaları (riski size ait olmak üzere kullanın)",
+    "communityAppSources": "Topluluk Uygulama Kaynakları",
     "allowInsecure": "Güvensiz HTTP isteklerine izin ver",
     "stayOneVersionBehind": "En son sürümün bir sürüm gerisinde kalın",
     "removeAppQuestion": {

--- a/assets/translations/tr.json
+++ b/assets/translations/tr.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "AppVerifier ile paylaşın, hazır olduğunuzda buraya dönün.",
     "wiki": "Yardım/Wiki",
     "crowdsourcedConfigsLabel": "Kitle Kaynaklı Uygulama Yapılandırmaları (riski size ait olmak üzere kullanın)",
-    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
+    "crowdsourcedConfigsShort": "Kitle Kaynaklı Uygulama Yapılandırmaları",
     "allowInsecure": "Güvensiz HTTP isteklerine izin ver",
     "stayOneVersionBehind": "En son sürümün bir sürüm gerisinde kalın",
     "removeAppQuestion": {

--- a/assets/translations/tr.json
+++ b/assets/translations/tr.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "AppVerifier ile paylaşın, hazır olduğunuzda buraya dönün.",
     "wiki": "Yardım/Wiki",
     "crowdsourcedConfigsLabel": "Kitle Kaynaklı Uygulama Yapılandırmaları (riski size ait olmak üzere kullanın)",
-    "communityAppSources": "Topluluk Uygulama Kaynakları",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Güvensiz HTTP isteklerine izin ver",
     "stayOneVersionBehind": "En son sürümün bir sürüm gerisinde kalın",
     "removeAppQuestion": {

--- a/assets/translations/uk.json
+++ b/assets/translations/uk.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "Надішліть на AppVerifier, а потім поверніться сюди, коли будете готові.",
     "wiki": "Довідка/Вікі",
     "crowdsourcedConfigsLabel": "Краудсорсингові конфігурації додатків (використовуйте на свій страх і ризик)",
+    "communityAppSources": "Ресурси програми спільноти",
     "allowInsecure": "Дозволити незахищені HTTP-запити",
     "stayOneVersionBehind": "Залишайтеся на одну версію актуальнішою",
     "removeAppQuestion": {

--- a/assets/translations/uk.json
+++ b/assets/translations/uk.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Надішліть на AppVerifier, а потім поверніться сюди, коли будете готові.",
     "wiki": "Довідка/Вікі",
     "crowdsourcedConfigsLabel": "Краудсорсингові конфігурації додатків (використовуйте на свій страх і ризик)",
-    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
+    "crowdsourcedConfigsShort": "Налаштування краудсорсингових додатків",
     "allowInsecure": "Дозволити незахищені HTTP-запити",
     "stayOneVersionBehind": "Залишайтеся на одну версію актуальнішою",
     "removeAppQuestion": {

--- a/assets/translations/uk.json
+++ b/assets/translations/uk.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Надішліть на AppVerifier, а потім поверніться сюди, коли будете готові.",
     "wiki": "Довідка/Вікі",
     "crowdsourcedConfigsLabel": "Краудсорсингові конфігурації додатків (використовуйте на свій страх і ризик)",
-    "communityAppSources": "Ресурси програми спільноти",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Дозволити незахищені HTTP-запити",
     "stayOneVersionBehind": "Залишайтеся на одну версію актуальнішою",
     "removeAppQuestion": {

--- a/assets/translations/vi.json
+++ b/assets/translations/vi.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "Chia sẻ lên AppVerifier, sau đó quay lại đây khi sẵn sàng.",
     "wiki": "Trợ giúp/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsourced App Configurations (use at your own risk)",
+    "communityAppSources": "Tài nguyên ứng dụng cộng đồng",
     "allowInsecure": "Allow insecure HTTP requests",
     "stayOneVersionBehind": "Stay one version behind latest",
     "removeAppQuestion": {

--- a/assets/translations/vi.json
+++ b/assets/translations/vi.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "Chia sẻ lên AppVerifier, sau đó quay lại đây khi sẵn sàng.",
     "wiki": "Trợ giúp/Wiki",
     "crowdsourcedConfigsLabel": "Crowdsourced App Configurations (use at your own risk)",
-    "communityAppSources": "Tài nguyên ứng dụng cộng đồng",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Allow insecure HTTP requests",
     "stayOneVersionBehind": "Stay one version behind latest",
     "removeAppQuestion": {

--- a/assets/translations/zh-Hant-TW.json
+++ b/assets/translations/zh-Hant-TW.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "分享至 AppVerifier，然後準備好時回到此處。",
     "wiki": "幫助/維基",
     "crowdsourcedConfigsLabel": "群眾外包的應用程式設定（使用風險自負）",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "Allow insecure HTTP requests",
     "stayOneVersionBehind": "Stay one version behind latest",
     "removeAppQuestion": {

--- a/assets/translations/zh.json
+++ b/assets/translations/zh.json
@@ -315,6 +315,7 @@
     "appVerifierInstructionToast": "分享至 AppVerifier，完成后返回此处。",
     "wiki": "帮助/Wiki",
     "crowdsourcedConfigsLabel": "众包应用程序配置（使用风险自负）",
+    "communityAppSources": "社区应用程序源",
     "allowInsecure": "允许不安全的 HTTP 请求",
     "stayOneVersionBehind": "比最新版本晚一个版本",
     "removeAppQuestion": {

--- a/assets/translations/zh.json
+++ b/assets/translations/zh.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "分享至 AppVerifier，完成后返回此处。",
     "wiki": "帮助/Wiki",
     "crowdsourcedConfigsLabel": "众包应用程序配置（使用风险自负）",
-    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
+    "crowdsourcedConfigsShort": "众包应用程序配置",
     "allowInsecure": "允许不安全的 HTTP 请求",
     "stayOneVersionBehind": "比最新版本晚一个版本",
     "removeAppQuestion": {

--- a/assets/translations/zh.json
+++ b/assets/translations/zh.json
@@ -315,7 +315,7 @@
     "appVerifierInstructionToast": "分享至 AppVerifier，完成后返回此处。",
     "wiki": "帮助/Wiki",
     "crowdsourcedConfigsLabel": "众包应用程序配置（使用风险自负）",
-    "communityAppSources": "社区应用程序源",
+    "crowdsourcedConfigsShort": "Crowdsourced App Configs",
     "allowInsecure": "允许不安全的 HTTP 请求",
     "stayOneVersionBehind": "比最新版本晚一个版本",
     "removeAppQuestion": {

--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -618,6 +618,12 @@ class AddAppPageState extends State<AddAppPage> {
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
+                      ElevatedButton(onPressed: 
+                          doingSomething ? null :
+                      (){
+                        launchUrlString('https://apps.obtainium.imranr.dev/',
+                            mode: LaunchMode.externalApplication);
+                      }, child: Text(tr('communityAppSources'))),
                       getUrlInputRow(),
                       const SizedBox(
                         height: 16,

--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -544,6 +544,7 @@ class AddAppPageState extends State<AddAppPage> {
     Widget getSourcesListWidget() => Padding(
           padding: const EdgeInsets.all(16),
           child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               GestureDetector(
                   onTap: () {
@@ -600,7 +601,20 @@ class AddAppPageState extends State<AddAppPage> {
                         fontWeight: FontWeight.bold,
                         decoration: TextDecoration.underline,
                         fontStyle: FontStyle.italic),
-                  ))
+                  )),
+              GestureDetector(
+                onTap: () {
+                  launchUrlString('https://apps.obtainium.imranr.dev/',
+                      mode: LaunchMode.externalApplication);
+                },
+                child: Text(
+                  tr('crowdsourcedConfigsShort'),
+                  style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      decoration: TextDecoration.underline,
+                      fontStyle: FontStyle.italic),
+                ),
+              ),
             ],
           ),
         );
@@ -618,12 +632,6 @@ class AddAppPageState extends State<AddAppPage> {
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
-                      ElevatedButton(onPressed: 
-                          doingSomething ? null :
-                      (){
-                        launchUrlString('https://apps.obtainium.imranr.dev/',
-                            mode: LaunchMode.externalApplication);
-                      }, child: Text(tr('communityAppSources'))),
                       getUrlInputRow(),
                       const SizedBox(
                         height: 16,


### PR DESCRIPTION
**Resolves #1727**

This pull request introduces a new button labeled **"Community App Sources"** to the **AddAppPage**. When clicked, this button will open an external application with the URL: [https://apps.obtainium.imranr.dev/](https://apps.obtainium.imranr.dev/). Translations for the "Community App Sources" label have been included for multiple languages to ensure international support.

### Changes in this PR:
- Added a **"Community App Sources"** button on the **AddAppPage**
- Integrated translations for the button text across various languages
- Launched an external URL when the button is clicked

### Screenshots:

<details>
  <summary>Dark Mode</summary>
  
  ![Screenshot_dark](https://github.com/user-attachments/assets/72bc8418-87c8-4985-93da-e20bd315d7c8)
  
</details>

<details>
  <summary>Light Mode</summary>
  
  ![Screenshot_light](https://github.com/user-attachments/assets/0936f273-613c-4514-8735-26884b2b042f)
  
</details>