### PR TITLE
Allow installation of the debug build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -81,6 +81,10 @@ android {
         release {
             signingConfig signingConfigs.release
         }
+        debug {
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
+        }
     }
 }
 

--- a/android/app/src/debug/res/values/string.xml
+++ b/android/app/src/debug/res/values/string.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="label">Obtainium Debug</string>
+</resources>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="dev.imranr.obtainium">
     <application
-        android:label="Obtainium"
+        android:label="@string/label"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:requestLegacyExternalStorage="true"

--- a/android/app/src/main/res/values/string.xml
+++ b/android/app/src/main/res/values/string.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="label">Obtainium</string>
+</resources>


### PR DESCRIPTION
This permits the debug build to be installed side-by-side with the release/f-droid version so it's easier to debug without uninstalling/reinstalling constantly