### PR TITLE
Correction of long translations (French)

### DIFF
--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -313,8 +313,8 @@
     "beforeNewInstallsShareToAppVerifier": "Partager les nouvelles applications avec AppVerifier (si disponible)",
     "appVerifierInstructionToast": "Partagez avec AppVerifier, puis revenez ici lorsque tout est prêt.",
     "wiki": "Aide/Wiki",
-    "crowdsourcedConfigsLabel": "Configurations d'applis communautaire (à utiliser à vos risques et périls)",
-    "crowdsourcedConfigsShort": "Configuration d'applis communautaire",
+    "crowdsourcedConfigsLabel": "Configuration d'applis communautaire (à utiliser à vos risques et périls)",
+    "crowdsourcedConfigsShort": "Applis communautaires",
     "allowInsecure": "Autoriser les requêtes HTTP non sécurisées",
     "stayOneVersionBehind": "Rester à une version de la dernière",
     "removeAppQuestion": {


### PR DESCRIPTION
- The previous correction was still too long, so I corrected it again.
- Line 317: "Configuration d'applis communautaire" changed by "Applis communautaires"
- translation suggested by @peternmuller