### PR TITLE
Avoid OS version reconciliation for pseudo-versioned apps (#2023), When importing configs via link, don't show dialog twice, GitHub - do not use filtered asset release dates (#2012)

### DIFF
--- a/lib/pages/apps.dart
+++ b/lib/pages/apps.dart
@@ -838,30 +838,6 @@ class AppsPageState extends State<AppsPage> {
       Navigator.of(context).pop();
     }
 
-    resetSelectedAppsInstallStatuses() async {
-      try {
-        var values = await showDialog(
-            context: context,
-            builder: (BuildContext ctx) {
-              return GeneratedFormModal(
-                title: tr('resetInstallStatusForSelectedAppsQuestion'),
-                items: const [],
-                initValid: true,
-                message: tr('installStatusOfXWillBeResetExplanation',
-                    args: [plural('apps', selectedAppIds.length)]),
-              );
-            });
-        if (values != null) {
-          appsProvider.saveApps(selectedApps.map((e) {
-            e.installedVersion = null;
-            return e;
-          }).toList());
-        }
-      } finally {
-        Navigator.of(context).pop();
-      }
-    }
-
     showMoreOptionsDialog() {
       return showDialog(
           context: context,

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -130,13 +130,18 @@ class _HomePageState extends State<HomePage> {
 
     // Check initial link if app was in cold state (terminated)
     final appLink = await _appLinks.getInitialLink();
+    var initLinked = false;
     if (appLink != null) {
       await interpretLink(appLink);
+      initLinked = true;
     }
-
     // Handle link when app is in warm state (front or background)
     _linkSubscription = _appLinks.uriLinkStream.listen((uri) async {
-      await interpretLink(uri);
+      if (!initLinked) {
+        await interpretLink(uri);
+      } else {
+        initLinked = false;
+      }
     });
   }
 

--- a/lib/providers/source_provider.dart
+++ b/lib/providers/source_provider.dart
@@ -151,10 +151,6 @@ appJSONCompatibilityModifiers(Map<String, dynamic> json) {
     additionalSettings['autoApkFilterByArch'] = false;
   }
   if (source.runtimeType == HTML().runtimeType) {
-    // HTML 'fixed URL' support should be disabled if it previously did not exist
-    if (originalAdditionalSettings['supportFixedAPKURL'] == null) {
-      additionalSettings['supportFixedAPKURL'] = false;
-    }
     // HTML key rename
     if (originalAdditionalSettings['sortByFileNamesNotLinks'] != null) {
       additionalSettings['sortByLastLinkSegment'] =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.34+2291
+version: 1.1.35+2292
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
- Avoid OS version reconciliation for pseudo-versioned apps (#2023)
- When importing configs via link, don't show dialog twice
- GitHub - do not use filtered asset release dates (#2012)