### PR TITLE
Add support for building via a docker container [remote dev]

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+LICENSE.md
+README.md
+analysis_options.yaml
+android
+assets
+build
+build.sh
+data
+docker
+fastlane
+lib
+pubspec.lock
+pubspec.yaml
+sign.sh
+test

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ app.*.map.json
 
 # Custom
 TODO.txt
+data

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,84 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV ANDROID_SDK_ROOT /opt/android-sdk-linux
+ENV PATH "${PATH}:/opt/flutter/bin:/root/.pub-cache/bin:${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin:/opt/android-sdk-linux/platform-tools"
+
+ENV HOME=/root
+
+# Prereqs
+RUN \
+    apt-get update &&\
+    apt-get install -y --no-install-recommends \
+        bash \
+        curl \
+        file \
+        git 2.x \
+        unzip \
+        xz-utils \
+        zip \
+        libglu1-mesa \
+        libxi-dev \
+        libxmu-dev \
+        libglu1-mesa-dev \
+        git-lfs \
+        openssl \
+        wget
+
+# Build prereqs
+RUN \
+    apt-get install -y \
+        cmake curl git wget unzip libgconf-2-4 gdb libstdc++6 libglu1-mesa fonts-droid-fallback lib32stdc++6 python3 sed \
+        cmake ninja-build build-essential libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev clang pkg-config libgtk-3-dev \
+        liblzma-dev libmount-dev libblkid-dev libgcrypt20-dev libgpg-error-dev libssl-dev libpng-dev libjpeg-dev \
+        libtiff-dev libgif-dev libgtk-3-dev
+
+# Android SDK prequisites
+# https://developer.android.com/studio#command-tools
+RUN \
+    apt-get install -y --no-install-recommends \
+        git \
+        git-lfs \
+        openssl \
+        wget \
+        unzip
+# Android SDK
+RUN \
+    wget --quiet  https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip -O /tmp/tools.zip && \
+    mkdir -p ${ANDROID_SDK_ROOT}/cmdline-tools && \
+    unzip -q /tmp/tools.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools && \
+    mv ${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/latest && \
+    rm -v /tmp/tools.zip && \
+    mkdir -p /root/.android/ && touch /root/.android/repositories.cfg &&\
+    apt-get install -y --no-install-recommends openjdk-17-jdk openjdk-17-jre &&\
+    yes | sdkmanager --licenses &&\
+    sdkmanager --update
+# Platform tools
+# Get latest with sdkmanager --list
+RUN sdkmanager --install "build-tools;33.0.1"
+RUN sdkmanager --install "ndk;26.3.11579264"
+RUN sdkmanager --install "cmake;3.31.4"
+RUN sdkmanager --install platform-tools
+RUN sdkmanager --install emulator
+RUN sdkmanager --install tools
+RUN sdkmanager --install "platforms;android-28"
+RUN sdkmanager --install "platforms;android-31"
+RUN sdkmanager --install "platforms;android-33"
+RUN sdkmanager --install "platforms;android-35"
+RUN sdkmanager --install "platforms;android-34"
+RUN sdkmanager --install "platforms;android-32"
+
+# Flutter
+ARG DEV_UID=0
+RUN \
+    wget --quiet https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.29.0-stable.tar.xz -O /tmp/flutter.tar.xz &&\
+    mkdir -p /opt &&\
+    cd /opt &&\
+    tar xf /tmp/flutter.tar.xz &&\
+    rm /tmp/flutter.tar.xz &&\
+    git config --global --add safe.directory /opt/flutter &&\
+    dart pub global activate cider &&\
+    chown -R ${DEV_UID} /opt/flutter
+RUN flutter --disable-analytics
+RUN flutter upgrade
+RUN chmod a+w /opt/flutter/packages -R

--- a/docker/builder.sh
+++ b/docker/builder.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+cd ${SCRIPT_DIR}/..
+mkdir -p ./data/home
+docker run \
+    --rm \
+    -ti \
+    --net host \
+    -v "${PWD}/../:${PWD}/../" \
+    -w "${PWD}" \
+    --name flutter-dev-obtainium \
+    --user $(id -u) \
+    -v ./data/home:/home/${USER} \
+    -e USER=${USER} \
+    -e HOME=/home/${USER} \
+    -e ANDROID_USER_HOME=${HOME}/.android \
+    -e GRADLE_USER_HOME=${HOME}/.gradle \
+    -e PS1="${debian_chroot:+($debian_chroot)}${USER}@\h:\w\$ " \
+    flutter-builder-obtainium

--- a/docker/mkbuilder.sh
+++ b/docker/mkbuilder.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+D=$(date +'%Y%m%d.%H%M%S%3N')
+
+set -e
+
+cd "${SCRIPT_DIR}/.."
+# Create the builder image
+docker build \
+    -t flutter-builder-obtainium \
+    -f ./docker/Dockerfile \
+    --build-arg="DEV_UID=$(id -u)" \
+    .


### PR DESCRIPTION
When developing on a remote `code-server`, it is common practice to have a remote build environment specific to the application. This PR provides a set of scripts that allow developers to set up this environment.

## Usage example

On the host
```bash
# Build the docker image
./docker/mkbuilder.sh

# Start the docker image
./docker/builder.sh
```

Now that you're in the running container:
```bash
# Connect to a remote emulator
adb connect localhost:7775

# Run the app
flutter run --flavor normal
```

Exiting the container will remove it.