### PR TITLE
fix: automatically export on changes (#2209)

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -265,7 +265,7 @@
     "matchGroupToUse": "Match group to use for version string extraction RegEx",
     "highlightTouchTargets": "Highlight less obvious touch targets",
     "pickExportDir": "Pick export directory",
-    "autoExportOnChanges": "Auto-export on changes",
+    "autoExportOnChanges": "Automatically export on changes",
     "includeSettings": "Include settings",
     "filterVersionsByRegEx": "Filter versions by regular expression",
     "trySelectingSuggestedVersionCode": "Try selecting suggested versionCode APK",


### PR DESCRIPTION
## Issue Reference
Closes #2209

## Summary
This PR updates the setting label from:
- "Auto-export on changes"
to:
- "Automatically export on changes"

## Reason for Change
Improves readability and aligns with consistent naming conventions.

## Testing
- Verified the label change in the UI
- No functional impact, purely a text update
