### PR TITLE
bugfix: invalid version codes for some apkpure links

### DIFF
--- a/lib/app_sources/apkpure.dart
+++ b/lib/app_sources/apkpure.dart
@@ -131,7 +131,7 @@ class APKPure extends AppSource {
         var link =
             html.querySelector("a.download-start-btn")?.attributes['href'];
         RegExp downloadLinkRegEx = RegExp(
-            r'^https:\/\/d\.[^/]+\/b\/([^/]+)\/[^/?]+\?versionCode=([0-9]+).$',
+            r'^https:\/\/d\.[^/]+\/b\/([^/]+)\/[^/?]+\?versionCode=([0-9]+)$',
             caseSensitive: false);
         RegExpMatch? match = downloadLinkRegEx.firstMatch(link ?? '');
         if (match == null) {


### PR DESCRIPTION
I'm really sorry, but apparently a really stupid bug slipped into my code in #2290 resulting in invalid version codes (last digit was cut off). I only tested if i could add and see the new versions not if the download was actually working.

The bug is now fixed and I tested it completely this time. (both adding and downloading an app)