### PR TITLE
Implement suggested version code for third-party F-Droid repos (#2524)

### DIFF
--- a/lib/app_sources/fdroid.dart
+++ b/lib/app_sources/fdroid.dart
@@ -32,6 +32,7 @@ class FDroid extends AppSource {
         GeneratedFormSwitch(
           'trySelectingSuggestedVersionCode',
           label: tr('trySelectingSuggestedVersionCode'),
+          defaultValue: true,
         ),
       ],
       [


### PR DESCRIPTION
Enable it by default for both official and third-party F-Droid sources.

Reuse trySelectingSuggestedVersionCode label from official F-Droid repository source.