### PR TITLE
Fixed parsing so now it can find APK links in HTML pages better (added trailing code artifacts cleaning in getLinksInLines)

### DIFF
--- a/lib/app_sources/html.dart
+++ b/lib/app_sources/html.dart
@@ -109,7 +109,7 @@ List<MapEntry<String, String>> getLinksInLines(String lines) =>
           (match) {
             // Clean the URL of trailing code artifacts
             String url = match.group(0)!;
-            final garbage = ["'", '"', ";", ")", "]", "<", ">", ","];
+            final garbage = ["'", '"', ";", ")", "}", "]", "<", ">", ","];
 
             // Keep removing the last character if it is "garbage"
             while (url.isNotEmpty && garbage.contains(url[url.length - 1])) {


### PR DESCRIPTION
### Rationale
One of the apps I wanted to manage using Obtainium can only be downloaded by going to a page that runs a JS script that is manually changed by the app developers to redirect to the newest app version. I knew Obtainium can parse raw HTML pages for links, so I investigated, found the underlying issue, and wrote a fix.

### The addressed issue
The regex that parses raw html pages in "HTML" (Fallback) matches all non-space characters, including those that shouldn't be part of the URL.

For example, consider a page that contains
```html
<body>

<script type="text/JavaScript">

setTimeout(function(){
    location.href = 'https://example.com/app-1.1.1-a.apk';
}, 1000);

</script>

Download hasn't started?
<a href="https://example.com/app-1.1.1-a.apk"> Click here to get latest apk </a>
(This link leads to https://example.com/app-1.1.1-a.apk)

</body>
```
It would get parsed by `getLinksInLines(String lines)` in `html.dart`, and before the fix, the output of that function, when given `lines` containing the HTML above, would be 
```
[MapEntry(https://example.com/app-1.1.1-a.apk';: app-1.1.1-a.apk';), MapEntry(https://example.com/app-1.1.1-a.apk">: app-1.1.1-a.apk">), MapEntry(https://example.com/app-1.1.1-a.apk): app-1.1.1-a.apk))]
```
(i.e. the found links `https://example.com/app-1.1.1-a.apk';`, `https://example.com/app-1.1.1-a.apk">`, and `https://example.com/app-1.1.1-a.apk)` would contain trailing code artifacts, preventing them from being considered APK file links)

### The fix
The anonymous function that fills out the MapEntry was changed so the links are now cleaned of these trailing code artifact characters by a while loop that removes them from the end of the URL, and only then added to the MapEntry.

When passed the HTML snippet above, `getLinksInLines(String lines)` now returns
```
[MapEntry(https://example.com/app-1.1.1-a.apk: app-1.1.1-a.apk), MapEntry(https://example.com/app-1.1.1-a.apk: app-1.1.1-a.apk), MapEntry(https://example.com/app-1.1.1-a.apk: app-1.1.1-a.apk)]
```
meaning the links are parsed correctly. I complied the apk from the modified source code and it, unlike the most recent Obtainium release, could find the app I was having issues with.
