### PR TITLE
Fix existing Signal configurations that use the website source

### DIFF
--- a/lib/providers/source_provider.dart
+++ b/lib/providers/source_provider.dart
@@ -238,6 +238,20 @@ Map<String, dynamic> appJSONCompatibilityModifiers(Map<String, dynamic> json) {
           '\\d+.\\d+.\\d+';
       additionalSettings = replacementAdditionalSettings;
     }
+    // Signal from the website from before the apk filenames stopped including the version (#2715)
+    if (json['url'] == 'https://updates.signal.org/android/latest.json' &&
+        json['id'] == 'org.thoughtcrime.securesms' &&
+        json['overrideSource'] == null &&
+        additionalSettings['versionExtractWholePage'] == false &&
+        json['lastUpdateCheck'] != null) {
+      var replacementAdditionalSettings = getDefaultValuesFromFormItems(
+        HTML().combinedAppSpecificSettingFormItems,
+      );
+      replacementAdditionalSettings['versionExtractWholePage'] = true;
+      replacementAdditionalSettings['versionExtractionRegEx'] = '"versionName"\\s*:\\s*"([^"]*)"';
+      replacementAdditionalSettings['matchGroupToUse'] = '\$1';
+      additionalSettings = replacementAdditionalSettings;
+    }
     // WhatsApp from before it was removed should be converted to HTML (#1943)
     if (json['url'] == 'https://whatsapp.com' &&
         json['id'] == 'com.whatsapp' &&


### PR DESCRIPTION
Closes #2715
Closes ImranR98/apps.obtainium.imranr.dev#1136

Existing configurations for the Signal app that use the source from the Signal website (`https://updates.signal.org/android/latest.json`) were broken starting from Signal version 7.69 because the apks stopped including the version name in the filenames.

I made the change in the file `source_provider.dart` by adapting the previous Signal configuration change that was there. The changes are:
- Set `"versionExtractWholePage"` to `true`; that is: toggle on the option _Apply version string extraction Regex to entire page_.
- Change the RegEx filter `"versionExtractionRegEx"` (which is the option _Version string extraction RegEx_) to the following, to extract the field `versionName` from the JSON:
  ```regex
  "versionName"\s*:\s*"([^"]*)"
  ```
- Set `"matchGroupToUse"` (which is the setting _Match group to use for version string extraction RegEx_) to `$1`.

I don't know if this kind of migration is something that needs to be done by the Obtainium app, I am just putting this here in case it could be useful.

I am not sure the changes I made are correct. Also, I put them after the previous Signal modification, instead of replacing that.

Note that configurations that get Signal from GitHub releases are unaffected by this change. Also unaffected are existing configurations that have `versionExtractWholePage` already set to `true`.

(See also ImranR98/apps.obtainium.imranr.dev#1131 for updating the configuration offered from [https://apps.obtainium.imranr.dev/](https://apps.obtainium.imranr.dev/))