### PR TITLE
fix: ensure apps with unknown release dates sort to the bottom in descending order

### DIFF
--- a/lib/pages/apps.dart
+++ b/lib/pages/apps.dart
@@ -279,17 +279,19 @@ class AppsPageState extends State<AppsPage> {
         // Handle null dates: apps with unknown release dates are grouped at the end
         final aDate = a.app.releaseDate;
         final bDate = b.app.releaseDate;
+        final isDescending =
+            settingsProvider.sortOrder == SortOrderSettings.descending;
         if (aDate == null && bDate == null) {
           // Both null: sort by name for consistency
           result = ((a.name + a.author).toLowerCase()).compareTo(
             (b.name + b.author).toLowerCase(),
           );
         } else if (aDate == null) {
-          // a has no date, push to end (ascending) or beginning (will be reversed for descending)
-          result = 1;
+          // a has no date, always push to end regardless of sort direction
+          result = isDescending ? -1 : 1;
         } else if (bDate == null) {
-          // b has no date, push to end
-          result = -1;
+          // b has no date, always push to end regardless of sort direction
+          result = isDescending ? 1 : -1;
         } else {
           result = aDate.compareTo(bDate);
         }


### PR DESCRIPTION
**Changes**
Fixed a UX regression where apps without a release date (e.g., F-Droid apps) would appear at the top of the list when sorting by "Release Date: Descending."

Previously, null dates were pushed to the end of the list before the list was reversed for descending order, inadvertently moving them to the very top.

**Implementation**
- Updated the sorting comparator in `AppsPage` to account for the sort direction (ascending vs. descending) when handling `null` dates.
- Apps with unknown dates will now always be pushed to the bottom of the visible list, regardless of the sort order.
- Extracted the `isDescending` check for better code readability.

**Related Issue**
Fixes #2724

**Testing**

https://github.com/user-attachments/assets/714a8904-d3c4-4764-9331-474fff5a78f8

