### PR TITLE
Implement SHOW_APP_INFO action.

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -40,6 +40,10 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="obtainium" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SHOW_APP_INFO" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/android/app/src/main/kotlin/dev/imranr/obtainium/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/imranr/obtainium/MainActivity.kt
@@ -1,5 +1,53 @@
 package dev.imranr.obtainium
 
+import android.content.Intent
+import android.os.Bundle
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    private val CHANNEL = "dev.imranr.obtainium/intent"
+    private var pendingPackageName: String? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        handleIntent(intent)
+        setupMethodChannel()
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handleIntent(intent)
+    }
+
+    private fun setupMethodChannel() {
+        flutterEngine?.dartExecutor?.binaryMessenger?.let { messenger ->
+            MethodChannel(messenger, CHANNEL).setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "getPendingPackageName" -> {
+                        val packageName = pendingPackageName
+                        pendingPackageName = null
+                        result.success(packageName)
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+        }
+    }
+
+    private fun handleIntent(intent: Intent?) {
+        intent?.let {
+            if (it.action == "android.intent.action.SHOW_APP_INFO") {
+                val packageName = it.getStringExtra("android.intent.extra.PACKAGE_NAME")
+                packageName?.let {
+                    pendingPackageName = packageName
+                    flutterEngine?.dartExecutor?.binaryMessenger?.let { messenger ->
+                        MethodChannel(messenger, CHANNEL).invokeMethod("showAppInfo", packageName)
+                    }
+                    pendingPackageName = null
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/dev/imranr/obtainium/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/imranr/obtainium/MainActivity.kt
@@ -3,16 +3,17 @@ package dev.imranr.obtainium
 import android.content.Intent
 import android.os.Bundle
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
+import java.util.concurrent.ConcurrentLinkedQueue
 
 class MainActivity : FlutterActivity() {
     private val CHANNEL = "dev.imranr.obtainium/intent"
-    private var pendingPackageName: String? = null
+    private val pendingPackages = ConcurrentLinkedQueue<String>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         handleIntent(intent)
-        setupMethodChannel()
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -21,19 +22,21 @@ class MainActivity : FlutterActivity() {
         handleIntent(intent)
     }
 
-    private fun setupMethodChannel() {
-        flutterEngine?.dartExecutor?.binaryMessenger?.let { messenger ->
-            MethodChannel(messenger, CHANNEL).setMethodCallHandler { call, result ->
+    // Register method channel when the FlutterEngine is configured (embedding v2 recommended pattern).
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
+            .setMethodCallHandler { call, result ->
                 when (call.method) {
                     "getPendingPackageName" -> {
-                        val packageName = pendingPackageName
-                        pendingPackageName = null
-                        result.success(packageName)
+                        // Return next pending package name or null if none.
+                        val pkg = pendingPackages.poll()
+                        result.success(pkg)
                     }
                     else -> result.notImplemented()
                 }
             }
-        }
     }
 
     private fun handleIntent(intent: Intent?) {
@@ -41,11 +44,8 @@ class MainActivity : FlutterActivity() {
             if (it.action == "android.intent.action.SHOW_APP_INFO") {
                 val packageName = it.getStringExtra("android.intent.extra.PACKAGE_NAME")
                 packageName?.let {
-                    pendingPackageName = packageName
-                    flutterEngine?.dartExecutor?.binaryMessenger?.let { messenger ->
-                        MethodChannel(messenger, CHANNEL).invokeMethod("showAppInfo", packageName)
-                    }
-                    pendingPackageName = null
+                    // Queue it so Dart can pick it up when ready.
+                    pendingPackages.add(packageName)
                 }
             }
         }

--- a/android/app/src/main/kotlin/dev/imranr/obtainium/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/imranr/obtainium/MainActivity.kt
@@ -8,11 +8,19 @@ import io.flutter.plugin.common.MethodChannel
 import java.util.concurrent.ConcurrentLinkedQueue
 
 class MainActivity : FlutterActivity() {
-    private val CHANNEL = "dev.imranr.obtainium/intent"
+    private val channel = "dev.imranr.obtainium/intent"
     private val pendingPackages = ConcurrentLinkedQueue<String>()
+
+    // Whether Dart has signalled it's ready to receive pushed intents
+    @Volatile
+    private var dartIsReady = false
+
+    // Save the latest messenger for invoking methods when Dart is ready
+    private var lastBinaryMessenger: io.flutter.plugin.common.BinaryMessenger? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Capture initial intent (cold start)
         handleIntent(intent)
     }
 
@@ -25,18 +33,32 @@ class MainActivity : FlutterActivity() {
     // Register method channel when the FlutterEngine is configured (embedding v2 recommended pattern).
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
+        lastBinaryMessenger = flutterEngine.dartExecutor.binaryMessenger
 
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
-            .setMethodCallHandler { call, result ->
-                when (call.method) {
-                    "getPendingPackageName" -> {
-                        // Return next pending package name or null if none.
-                        val pkg = pendingPackages.poll()
-                        result.success(pkg)
-                    }
-                    else -> result.notImplemented()
+        val channel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channel)
+        channel.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "getPendingPackageName" -> {
+                    // Return next pending package name or null if none.
+                    val pkg = pendingPackages.poll()
+                    result.success(pkg)
                 }
+
+                "readyForIntents" -> {
+                    // Dart is ready to receive pushed intents. Drain queue by invoking showAppInfo.
+                    dartIsReady = true
+                    drainQueueToDart()
+                    result.success(true)
+                }
+
+                else -> result.notImplemented()
             }
+        }
+
+        // If Dart later registers, we still have the messenger for invokes
+        if (dartIsReady) {
+            drainQueueToDart()
+        }
     }
 
     private fun handleIntent(intent: Intent?) {
@@ -44,10 +66,37 @@ class MainActivity : FlutterActivity() {
             if (it.action == "android.intent.action.SHOW_APP_INFO") {
                 val packageName = it.getStringExtra("android.intent.extra.PACKAGE_NAME")
                 packageName?.let {
-                    // Queue it so Dart can pick it up when ready.
-                    pendingPackages.add(packageName)
+                    if (dartIsReady && lastBinaryMessenger != null) {
+                        // Deliver immediately to Dart
+                        try {
+                            MethodChannel(lastBinaryMessenger!!, channel)
+                                .invokeMethod("showAppInfo", packageName)
+                        } catch (_: Exception) {
+                            // If invoke fails, fallback to queueing
+                            pendingPackages.add(packageName)
+                        }
+                    } else {
+                        // Queue it so Dart can pick it up when ready.
+                        pendingPackages.add(packageName)
+                    }
                 }
             }
+        }
+    }
+
+    private fun drainQueueToDart() {
+        val messenger = lastBinaryMessenger ?: return
+        val channel = MethodChannel(messenger, channel)
+        var pkg = pendingPackages.poll()
+        while (pkg != null) {
+            try {
+                channel.invokeMethod("showAppInfo", pkg)
+            } catch (_: Exception) {
+                // If invoke fails, requeue and stop draining to avoid busy loop
+                pendingPackages.add(pkg)
+                break
+            }
+            pkg = pendingPackages.poll()
         }
     }
 }

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -135,6 +135,7 @@
     "close": "Close",
     "share": "Share",
     "appNotFound": "App not found",
+    "appNotManagedByObtainium": "This app is not managed by Obtainium",
     "obtainiumExportHyphenatedLowercase": "obtainium-export",
     "pickAnAPK": "Pick an APK",
     "appHasMoreThanOnePackage": "{} has more than one package:",

--- a/assets/translations/zh.json
+++ b/assets/translations/zh.json
@@ -135,6 +135,7 @@
     "close": "关闭",
     "share": "分享",
     "appNotFound": "未找到应用",
+    "appNotManagedByObtainium": "此应用不由 Obtainium 管理",
     "obtainiumExportHyphenatedLowercase": "obtainium-export",
     "pickAnAPK": "选择一个 APK 文件",
     "appHasMoreThanOnePackage": "“{}”有多个架构可用：",

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -329,8 +329,11 @@ class _HomePageState extends State<HomePage> {
 
     // Check for pending package name from initial intent
     try {
-      String? pendingPackage = await platform.invokeMethod('getPendingPackageName');
-      if (pendingPackage != null) {
+      // Keep polling the native side until it returns null.
+      while (true) {
+        final pendingPackage =
+        await platform.invokeMethod<String>('getPendingPackageName');
+        if (pendingPackage == null) break;
         await handleShowAppInfo(pendingPackage);
       }
     } catch (e) {


### PR DESCRIPTION
When a SHOW_APP_INFO intent is received, the app details page for the package is displayed if available. Otherwise, a hint is shown to let the user know the app is not unknown to Obtainium.

Tested with `adb shell am start -a "android.intent.action.SHOW_APP_INFO" -n "dev.imranr.obtainium/.MainActivity" --es "android.intent.extra.PACKAGE_NAME" "com.example.app"` and confirmed the following:
- Cold start with a managed package: shows app's page.
- Cold start with an unknown package: shows dialog.
- Resume with a managed package: shows app's page.
- Resume with an unknown package: shows dialog.

Disclaimer: I don't know Flutter or Dart. I generated the code with AI.

Fixes #2200