### PR TITLE
Add workflow to validate translation JSON

### DIFF
--- a/.github/workflows/translation-validate.yaml
+++ b/.github/workflows/translation-validate.yaml
@@ -1,0 +1,31 @@
+name: Validate translation files
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+        # we only need the JSON files
+      - name: Get JSON PR files
+        id: changed
+        # get only the changed files
+        run: |
+          echo "files<<EOF" >> "$GITHUB_OUTPUT"
+          git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -E '^assets/translations/.*\.json$' || true >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+        
+
+      - name: Validate
+        if: steps.changed.outputs.files != ''
+        run: |
+          echo "Validating files: ${{ steps.changed.outputs.files }}"
+          jq empty ${{ steps.changed.outputs.files }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow `Validate translation files`, which will execute `jq` against added and modified JSON files within the `assets/translations` directory.

The steps are:

1. Checkout repo
2. Fetch the JSON files from the PR through viewing the diff, and only those that are in `assets/translations`
    - Also send filenames to Actions output
3. Perform silent validation of JSON files from previous step's output

I've noticed that some updates to the app are *only* for fixing broken translation files, I thought this workflow should help catch these problems before they're released