### PR TITLE
Fix combinedAppSpecificSettingFormItems mutating shared form item state

### DIFF
--- a/lib/providers/source_provider.dart
+++ b/lib/providers/source_provider.dart
@@ -644,26 +644,6 @@ abstract class AppSource {
     name = runtimeType.toString();
   }
 
-  void overrideAdditionalAppSpecificSourceAgnosticSettingSwitch(
-    String key, {
-    bool disabled = true,
-    bool defaultValue = true,
-  }) {
-    additionalAppSpecificSourceAgnosticSettingFormItemsNeverUseDirectly =
-        additionalAppSpecificSourceAgnosticSettingFormItemsNeverUseDirectly.map(
-          (e) {
-            return e.map((e2) {
-              if (e2.key == key) {
-                var item = e2 as GeneratedFormSwitch;
-                item.disabled = disabled;
-                item.defaultValue = defaultValue;
-              }
-              return e2;
-            }).toList();
-          },
-        ).toList();
-  }
-
   String standardizeUrl(String url) {
     url = preStandardizeUrl(url);
     if (!hostChanged) {
@@ -841,50 +821,33 @@ abstract class AppSource {
 
   // Previous 2 variables combined into one at runtime for convenient usage + additional processing
   List<List<GeneratedFormItem>> get combinedAppSpecificSettingFormItems {
-    if (showReleaseDateAsVersionToggle == true) {
-      if (additionalAppSpecificSourceAgnosticSettingFormItemsNeverUseDirectly
-              .indexWhere(
-                (List<GeneratedFormItem> e) =>
-                    e.indexWhere(
-                      (GeneratedFormItem i) => i.key == 'releaseDateAsVersion',
-                    ) >=
-                    0,
-              ) <
-          0) {
-        additionalAppSpecificSourceAgnosticSettingFormItemsNeverUseDirectly
-            .insert(
-              additionalAppSpecificSourceAgnosticSettingFormItemsNeverUseDirectly
-                      .indexWhere(
-                        (List<GeneratedFormItem> e) =>
-                            e.indexWhere(
-                              (GeneratedFormItem i) =>
-                                  i.key == 'versionDetection',
-                            ) >=
-                            0,
-                      ) +
-                  1,
-              [
-                GeneratedFormSwitch(
-                  'releaseDateAsVersion',
-                  label:
-                      '${tr('releaseDateAsVersion')} (${tr('pseudoVersion')})',
-                  defaultValue: false,
-                ),
-              ],
-            );
-      }
-    }
-    additionalAppSpecificSourceAgnosticSettingFormItemsNeverUseDirectly =
-        additionalAppSpecificSourceAgnosticSettingFormItemsNeverUseDirectly
-            .map(
-              (e) => e
-                  .where((ee) => !excludeCommonSettingKeys.contains(ee.key))
-                  .toList(),
-            )
-            .where((e) => e.isNotEmpty)
-            .toList();
+    var agnosticItems = cloneFormItems(
+        additionalAppSpecificSourceAgnosticSettingFormItemsNeverUseDirectly);
 
-    var moreConditionalItems = [];
+    final versionDetectionIdx = agnosticItems
+        .indexWhere((row) => row.any((item) => item.key == 'versionDetection'));
+    if (showReleaseDateAsVersionToggle &&
+        versionDetectionIdx >= 0 &&
+        !agnosticItems.any((row) => row.any((item) => item.key == 'releaseDateAsVersion'))) {
+      agnosticItems.insert(versionDetectionIdx + 1, [
+        GeneratedFormSwitch(
+          'releaseDateAsVersion',
+          label: '${tr('releaseDateAsVersion')} (${tr('pseudoVersion')})',
+          defaultValue: false,
+        ),
+      ]);
+    }
+
+    agnosticItems = agnosticItems
+        .map(
+          (e) => e
+              .where((ee) => !excludeCommonSettingKeys.contains(ee.key))
+              .toList(),
+        )
+        .where((e) => e.isNotEmpty)
+        .toList();
+
+    var moreConditionalItems = <List<GeneratedFormItem>>[];
     if (allowIncludeZips) {
       moreConditionalItems.addAll([
         [
@@ -910,20 +873,17 @@ abstract class AppSource {
     }
 
     if (versionDetectionDisallowed) {
-      overrideAdditionalAppSpecificSourceAgnosticSettingSwitch(
-        'versionDetection',
-        disabled: true,
-        defaultValue: false,
-      );
-      overrideAdditionalAppSpecificSourceAgnosticSettingSwitch(
-        'useVersionCodeAsOSVersion',
-        disabled: true,
-        defaultValue: false,
-      );
+      for (var item in agnosticItems.expand((row) => row)) {
+        if (item.key == 'versionDetection' || item.key == 'useVersionCodeAsOSVersion') {
+          (item as GeneratedFormSwitch).disabled = true;
+          (item as GeneratedFormSwitch).defaultValue = false;
+        }
+      }
     }
+
     return [
       ...additionalSourceAppSpecificSettingFormItems,
-      ...additionalAppSpecificSourceAgnosticSettingFormItemsNeverUseDirectly,
+      ...agnosticItems,
       ...moreConditionalItems,
     ];
   }


### PR DESCRIPTION
Discovered during an investigation: https://github.com/RJNY/Obtainium-Emulation-Pack/issues/104

There are two bugs, both related to how Obtainium manages per-app settings. 

The first is that the code responsible for building each app's settings screen modifies shared data in place instead of working on a copy, so settings from one app source can bleed into another. 

The fixe is straightforward, the settings builder now works on a copy of the data instead of the original. 

---

second "bug fix" was removed. keeping below for posterity.

~~The second is when Obtainium can't match an app's version string against a narrow set of recognized formats, it silently turns off version detection and saves the change to disk. This runs on every app load, so even if a user manually re-enables it, it gets switched off again immediately.~~

~~instead of disabling version detection when formats don't match, the app falls back to a simpler comparison that just checks if the two version strings are identical. This is the same approach Obtainium already uses for 9 other app sources like F-Droid and APKPure~~

~~Note that apps already affected will need version detection manually re-enabled after updating.~~