### PR TITLE
format last update check time without milliseconds

### DIFF
--- a/lib/pages/app.dart
+++ b/lib/pages/app.dart
@@ -141,12 +141,13 @@ class _AppPageState extends State<AppPage> {
       if (!upToDate) {
         versionLines += '\n${app?.app.latestVersion} ${tr('latest')}';
       }
+      final lastUpdateCheck = app?.app.lastUpdateCheck?.toLocal();
       String infoLines = tr(
         'lastUpdateCheckX',
         args: [
-          app?.app.lastUpdateCheck == null
+          lastUpdateCheck == null
               ? tr('never')
-              : '${app?.app.lastUpdateCheck?.toLocal()}',
+              : lastUpdateCheck.toString().split('.').first,
         ],
       );
       if (trackOnly) {


### PR DESCRIPTION
Users don't need such precision, and a long date can lead to ugly line breaks in other locales:

<table>
<tr>

<th>
Before:

<th>
After:

<tr>
<td>

<img width="1080" height="2400" src="https://github.com/user-attachments/assets/96867432-3e45-44d1-bd3d-8706151bcbe0" />

<td>

<img width="1080" height="2400" src="https://github.com/user-attachments/assets/3d16c506-67e9-43ae-816c-166b975d941a" />

</table>


