### PR TITLE
fix(forgejo-codeberg):Preserve scheme, host, and port in Forgejo API URL construction

### DIFF
--- a/lib/app_sources/codeberg.dart
+++ b/lib/app_sources/codeberg.dart
@@ -40,7 +40,13 @@ class Codeberg extends AppSource {
     return await gh.getLatestAPKDetailsCommon2(standardUrl, additionalSettings, (
       bool useTagUrl,
     ) async {
-      return 'https://${hosts[0]}/api/v1/repos${standardUrl.substring('https://${hosts[0]}'.length)}/${useTagUrl ? 'tags' : 'releases'}?per_page=100';
+      final standardUri = Uri.parse(standardUrl);
+      final apiPath =
+          '/api/v1/repos${standardUri.path}/${useTagUrl ? 'tags' : 'releases'}';
+      return standardUri.replace(
+        path: apiPath,
+        queryParameters: {'per_page': '100'},
+      ).toString();
     }, null);
   }
 


### PR DESCRIPTION
This will fix https://github.com/ImranR98/Obtainium/issues/2556 

Mine was quite an edge use case for Obtainium, running a self-hosted forgejo build server on a port different than `80`. The parser got all confused and gave this dart io error which was hard to catch, didn't surfaced on logcat even, as it was in a quite low level part of dart.

It also fixes leading whitespace chars (and other chars) being converted to `%20`.