### PR TITLE
Fix czech translation

### DIFF
--- a/assets/translations/cs.json
+++ b/assets/translations/cs.json
@@ -94,7 +94,7 @@
     "author": "Autor",
     "upToDateApps": "Aktuální aplikace",
     "nonInstalledApps": "Nenainstalované aplikace",
-    "importExport": "Dovoz / vývoz",
+    "importExport": "Import / export",
     "settings": "Nastavení",
     "exportedTo": "Exportováno do {}",
     "obtainiumExport": "Export aplikace Obtainium",


### PR DESCRIPTION
The import/export string was translated to czech incorrectly. The meaning of "dovoz/vývoz" is import/export of goods.