### PR TITLE
Disable changelog rendering as Markdown for RuStore

### DIFF
--- a/lib/app_sources/rustore.dart
+++ b/lib/app_sources/rustore.dart
@@ -13,6 +13,7 @@ class RuStore extends AppSource {
     name = 'RuStore';
     naiveStandardVersionDetection = true;
     showReleaseDateAsVersionToggle = true;
+    changeLogIfAnyIsMarkDown = false;
   }
 
   @override


### PR DESCRIPTION
I was a bit annoyed by missing newlines in Rustore's changelog window. Turns out, it was caused by rendering plaintext as Markdown, which is not supported _(check e.g. this [changelog](https://www.rustore.ru/catalog/app/ru.nspk.mirpay/versions))_ by this store, thus eliminating single newlines.

<details>

<summary>Comparison</summary>

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img width="570" height="1205" alt="image" src="https://github.com/user-attachments/assets/c8e20d3d-44dd-4143-9daf-f8f8843b3f3b" />
 <td><img width="570" height="1205" alt="image" src="https://github.com/user-attachments/assets/fe7e43bf-c749-4bfd-9d34-adb14a828bb9" />
</table>

</details>


I looked through all sources that support changelog, it seems like others are either supporting Markdown or mostly mirror unrendered Markdown text from GitHub/GitLab releases, so RuStore appears the only sole target to update