### PR TITLE
Fix changelog dialog text clipping

### DIFF
--- a/lib/pages/apps.dart
+++ b/lib/pages/apps.dart
@@ -61,11 +61,14 @@ void showChangeLogDialog(
           changesUrl != null
               ? const SizedBox(height: 16)
               : const SizedBox.shrink(),
-          appSource.changeLogIfAnyIsMarkDown
-              ? SizedBox(
-                  width: MediaQuery.of(context).size.width,
-                  height: MediaQuery.of(context).size.height - 350,
-                  child: Markdown(
+          ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: MediaQuery.of(context).size.width,
+              maxHeight: MediaQuery.of(context).size.height * 0.6,
+            ),
+            child: appSource.changeLogIfAnyIsMarkDown
+                ? Markdown(
+                    shrinkWrap: true,
                     styleSheet: MarkdownStyleSheet(
                       blockquoteDecoration: BoxDecoration(
                         color: Theme.of(context).cardColor,
@@ -90,9 +93,9 @@ void showChangeLogDialog(
                         ...md.ExtensionSet.gitHubFlavored.inlineSyntaxes,
                       ],
                     ),
-                  ),
-                )
-              : Text(changeLog),
+                  )
+                : SingleChildScrollView(child: Text(changeLog)),
+          ),
         ],
         singleNullReturnButton: tr('ok'),
       );


### PR DESCRIPTION
Fixes #2177
Fixes the changelog dialog layout by replacing the fixed-height container with a constrained scrollable area. 

**Changes:** 

- Replace fixed dialog height with a max-height constraint based on screen size. 
- Enable scrolling for plain text changelogs. 
- Add shrinkWrap for markdown content 

**Tested:** 

- flutter analyze 
- Verified no new analyzer errors were introduced 