### PR TITLE
fix(search): use sourceIdentifier instead of name for overrideSource after search

### DIFF
--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -384,7 +384,7 @@ class AddAppPageState extends State<AddAppPage> {
                     }
                   }
                   return MapEntry(
-                    e.name,
+                    e.sourceIdentifier,
                     await e.search(searchQuery, querySettings: querySettings),
                   );
                 } catch (err) {


### PR DESCRIPTION
When selecting a result from the search dialog, runSearch() passed the source's translated display name as overrideSource, but getSource() matches against sourceIdentifier (the Dart class name). Since many sources now use tr() for their name, these values don't match (e.g. "F-Droid" vs "FDroid", "Forgejo (Codeberg)" vs "Codeberg"), causing getSource() to throw UnsupportedURLError silently, which set pickedSource to null and disabled the Add button with no error feedback.

This is the same kind of fix as a5aa5212 which addressed the override dropdown.