### PR TITLE
Place TW zh above zh locale for consistency, Fix blank search query being blocked on add-app page, restoring ability to list all apps in F-Droid third-party repos (from #3000), Add HandshakeException retry with staggered random delays for concurrent TLS failures during batch update checks (#3008), Add notification permission request on first non-TV launch and declare POST_NOTIFICATIONS in manifest (#3070), Fix download progress not updating on app list tiles because tileChild was computed outside ValueListenableBuilder

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -94,6 +94,7 @@
         android:maxSdkVersion="29" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and
          https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.

--- a/lib/components/app_list_tile.dart
+++ b/lib/components/app_list_tile.dart
@@ -453,145 +453,154 @@ class AppListTile extends StatelessWidget {
           )
         : null;
 
-    final tileChild = Semantics(
-      customSemanticsActions: <CustomSemanticsAction, VoidCallback>{
-        if (canInstall || canUpdate)
-          CustomSemanticsAction(
-            label: canUpdate ? tr('update') : tr('install'),
-          ): () {
-            if (!appsProvider.areDownloadsRunning()) {
-              appsProvider.downloadAndInstallLatestApps([
-                appId,
-              ], appNavigatorKey.currentContext);
-            }
-          },
-        CustomSemanticsAction(label: tr('remove')): () {
-          appsProvider.removeAppsWithModal(context, [_app]);
-        },
-      },
-      child: Container(
-        decoration: BoxDecoration(
-          gradient: categories.isEmpty
-              ? null
-              : LinearGradient(
-                  stops: stops,
-                  begin: const Alignment(-1, 0),
-                  end: const Alignment(-0.97, 0),
-                  colors: [
-                    ...categories.map(
-                      (e) => Color(
-                        settingsProvider.categories[e] ?? transparent,
-                      ).withAlpha(255),
-                    ),
-                    Color(transparent),
-                  ],
-                ),
-        ),
-        child: () {
-          final tile = ListTile(
-            autofocus: autofocus,
-            shape: borderRadius != null
-                ? RoundedSuperellipseBorder(borderRadius: borderRadius!)
-                : null,
-            tileColor: _app.pinned
-                ? Theme.of(
-                    context,
-                  ).colorScheme.onSurface.withValues(alpha: 0.06)
-                : Colors.transparent,
-            selectedTileColor: Theme.of(
-              context,
-            ).colorScheme.primary.withValues(alpha: _app.pinned ? 0.2 : 0.1),
-            selected: multiSelected || detailSelected,
-            leading: settingsProvider.isTV
-                ? null
-                : AppIconWidget(
-                    appId: _app.id,
-                    installed: appInMemory.installedInfo != null,
-                    appsProvider: appsProvider,
-                  ),
-            onLongPress: onToggleSelected,
-            title: Text(
-              maxLines: 1,
-              appInMemory.name,
-              style: TextStyle(
-                overflow: TextOverflow.ellipsis,
-                fontWeight: _app.pinned ? FontWeight.bold : FontWeight.normal,
-              ),
-            ),
-            subtitle: _app.hasPendingRepoRename
-                ? Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [_authorText(), _repoMovedRow(context)],
-                  )
-                : _authorText(),
-            trailing: appInMemory.downloadProgress != null
-                ? DownloadProgressTrailing(
-                    progress: appInMemory.downloadProgress!,
-                    receivedBytes: appInMemory.downloadReceivedBytes,
-                    totalBytes: appInMemory.downloadTotalBytes,
-                  )
-                : trailingRow,
-            onTap: onTap,
-          );
-          if (settingsProvider.isTV) {
-            return Row(
-              children: [
-                Checkbox(
-                  value: multiSelected,
-                  onChanged: (_) {
-                    onToggleSelected();
-                  },
-                ),
-                Expanded(child: tile),
-              ],
-            );
-          }
-          return tile;
-        }(),
-      ),
-    );
-
     return ValueListenableBuilder<double?>(
       valueListenable: appInMemory.downloadProgressNotifier,
-      builder: (context, downloadProgress, child) =>
-          disableSwipe || downloadProgress != null
-          ? tileChild
-          : Dismissible(
-              key: ValueKey(appId),
-              direction: DismissDirection.horizontal,
-              background: swipeBackground ?? const SizedBox.shrink(),
-              secondaryBackground: Container(
-                color: cs.errorContainer,
-                alignment: Alignment.centerRight,
-                padding: const EdgeInsets.only(right: 24),
-                child: Icon(Icons.delete_outline, color: cs.onErrorContainer),
-              ),
-              confirmDismiss: (direction) async {
-                if (direction == DismissDirection.startToEnd) {
-                  if ((canInstall || canUpdate) &&
-                      !appsProvider.areDownloadsRunning()) {
-                    settingsProvider.heavyImpact();
-                    unawaited(
-                      appsProvider
-                          .downloadAndInstallLatestApps([
-                            appId,
-                          ], appNavigatorKey.currentContext)
-                          .catchError((e) {
-                            if (context.mounted) showError(e, context);
-                            return <String>[];
-                          }),
-                    );
-                  }
-                  return false;
-                } else {
-                  settingsProvider.lightImpact();
-                  return appsProvider.removeAppsWithModal(context, [_app]);
+      builder: (context, downloadProgress, child) {
+        final tileChild = Semantics(
+          customSemanticsActions: <CustomSemanticsAction, VoidCallback>{
+            if (canInstall || canUpdate)
+              CustomSemanticsAction(
+                label: canUpdate ? tr('update') : tr('install'),
+              ): () {
+                if (!appsProvider.areDownloadsRunning()) {
+                  appsProvider.downloadAndInstallLatestApps([
+                    appId,
+                  ], appNavigatorKey.currentContext);
                 }
               },
-              onDismissed: (direction) {},
-              child: tileChild,
+            CustomSemanticsAction(label: tr('remove')): () {
+              appsProvider.removeAppsWithModal(context, [_app]);
+            },
+          },
+          child: Container(
+            decoration: BoxDecoration(
+              gradient: categories.isEmpty
+                  ? null
+                  : LinearGradient(
+                      stops: stops,
+                      begin: const Alignment(-1, 0),
+                      end: const Alignment(-0.97, 0),
+                      colors: [
+                        ...categories.map(
+                          (e) => Color(
+                            settingsProvider.categories[e] ?? transparent,
+                          ).withAlpha(255),
+                        ),
+                        Color(transparent),
+                      ],
+                    ),
             ),
+            child: () {
+              final tile = ListTile(
+                autofocus: autofocus,
+                shape: borderRadius != null
+                    ? RoundedSuperellipseBorder(borderRadius: borderRadius!)
+                    : null,
+                tileColor: _app.pinned
+                    ? Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.06)
+                    : Colors.transparent,
+                selectedTileColor: Theme.of(context)
+                    .colorScheme
+                    .primary
+                    .withValues(alpha: _app.pinned ? 0.2 : 0.1),
+                selected: multiSelected || detailSelected,
+                leading: settingsProvider.isTV
+                    ? null
+                    : AppIconWidget(
+                        appId: _app.id,
+                        installed: appInMemory.installedInfo != null,
+                        appsProvider: appsProvider,
+                      ),
+                onLongPress: onToggleSelected,
+                title: Text(
+                  maxLines: 1,
+                  appInMemory.name,
+                  style: TextStyle(
+                    overflow: TextOverflow.ellipsis,
+                    fontWeight: _app.pinned
+                        ? FontWeight.bold
+                        : FontWeight.normal,
+                  ),
+                ),
+                subtitle: _app.hasPendingRepoRename
+                    ? Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          _authorText(),
+                          _repoMovedRow(context),
+                        ],
+                      )
+                    : _authorText(),
+                trailing: downloadProgress != null
+                    ? DownloadProgressTrailing(
+                        progress: downloadProgress,
+                        receivedBytes: appInMemory.downloadReceivedBytes,
+                        totalBytes: appInMemory.downloadTotalBytes,
+                      )
+                    : trailingRow,
+                onTap: onTap,
+              );
+              if (settingsProvider.isTV) {
+                return Row(
+                  children: [
+                    Checkbox(
+                      value: multiSelected,
+                      onChanged: (_) {
+                        onToggleSelected();
+                      },
+                    ),
+                    Expanded(child: tile),
+                  ],
+                );
+              }
+              return tile;
+            }(),
+          ),
+        );
+
+        return disableSwipe || downloadProgress != null
+            ? tileChild
+            : Dismissible(
+                key: ValueKey(appId),
+                direction: DismissDirection.horizontal,
+                background: swipeBackground ?? const SizedBox.shrink(),
+                secondaryBackground: Container(
+                  color: cs.errorContainer,
+                  alignment: Alignment.centerRight,
+                  padding: const EdgeInsets.only(right: 24),
+                  child: Icon(Icons.delete_outline,
+                      color: cs.onErrorContainer),
+                ),
+                confirmDismiss: (direction) async {
+                  if (direction == DismissDirection.startToEnd) {
+                    if ((canInstall || canUpdate) &&
+                        !appsProvider.areDownloadsRunning()) {
+                      settingsProvider.heavyImpact();
+                      unawaited(
+                        appsProvider
+                            .downloadAndInstallLatestApps([
+                              appId,
+                            ], appNavigatorKey.currentContext)
+                            .catchError((e) {
+                              if (context.mounted) showError(e, context);
+                              return <String>[];
+                            }),
+                      );
+                    }
+                    return false;
+                  } else {
+                    settingsProvider.lightImpact();
+                    return appsProvider.removeAppsWithModal(context, [_app]);
+                  }
+                },
+                onDismissed: (direction) {},
+                child: tileChild,
+              );
+      },
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,8 +20,8 @@ import 'package:workmanager/workmanager.dart';
 
 List<MapEntry<Locale, String>> supportedLocales = const [
   MapEntry(Locale('en'), 'English'),
-  MapEntry(Locale('zh'), '简体中文'),
   MapEntry(Locale('zh', 'Hant_TW'), '臺灣話'),
+  MapEntry(Locale('zh'), '简体中文'),
   MapEntry(Locale('it'), 'Italiano'),
   MapEntry(Locale('ja'), '日本語'),
   MapEntry(Locale('hu'), 'Magyar'),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:provider/provider.dart';
 import 'package:dynamic_system_colors/dynamic_system_colors.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:easy_localization/easy_localization.dart' hide TextDirection;
+import 'package:permission_handler/permission_handler.dart';
 import 'package:workmanager/workmanager.dart';
 
 List<MapEntry<Locale, String>> supportedLocales = const [
@@ -218,6 +219,9 @@ class _ObtainiumState extends State<Obtainium> {
     final isFirstRun = settings.checkAndFlipFirstRun();
     if (isFirstRun) {
       logger.info('This is the first ever run of Obtainium.');
+      if (!settings.isTV) {
+        unawaited(Permission.notification.request());
+      }
       if (!isFdroidBuild) {
         getInstalledInfo(obtainiumId)
             .then((value) {

--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -655,9 +655,7 @@ class AddAppPageState extends State<AddAppPage> {
         child: searching
             ? const Center(child: CircularProgressIndicator())
             : FilledButton(
-                onPressed: searchQuery.isEmpty || doingSomething
-                    ? null
-                    : () {
+                onPressed: doingSomething ? null : () {
                         runSearch(context);
                       },
                 child: Text(tr('search')),

--- a/lib/providers/apps_provider_updates.dart
+++ b/lib/providers/apps_provider_updates.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:obtainium/custom_errors.dart';
 import 'package:obtainium/providers/apps_provider.dart';
@@ -152,6 +153,30 @@ extension AppsProviderUpdates on AppsProvider {
                     currentApp != null &&
                     newApp.latestVersion != currentApp.latestVersion;
                 return MapEntry(newApp, isUpdate);
+              } on HandshakeException {
+                // Concurrent TLS handshakes to the same host can fail on
+                // certain devices/networks. Retry up to 5 times with
+                // staggered random delays to avoid all retries colliding.
+                const maxRetries = 5;
+                final rng = Random();
+                for (var attempt = 0; attempt < maxRetries; attempt++) {
+                  await Future.delayed(
+                    Duration(
+                      milliseconds: 250 + rng.nextInt(501),
+                    ),
+                  );
+                  try {
+                    final newApp = await fetchUpdate(appId);
+                    if (newApp == null) return null;
+                    final isUpdate =
+                        currentApp != null &&
+                        newApp.latestVersion != currentApp.latestVersion;
+                    return MapEntry(newApp, isUpdate);
+                  } on HandshakeException {
+                    if (attempt == maxRetries - 1) rethrow;
+                  }
+                }
+                return null;
               } catch (e) {
                 if ((e is RateLimitError || e is SocketException) &&
                     throwErrorsForRetry) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -908,10 +908,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "93ae5884a9df5d3bb696825bceb3a17590754548b5d740eba51500afc8d088f5"
+      sha256: "0634e64bd719f89c012f392938e173521f535d3ecaf66558fa94a056d22b5cc7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.26"
+    version: "2.4.27"
   shared_preferences_foundation:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: obtainium
 description: Get Android app updates straight from the source.
 publish_to: 'none'
 
-version: 1.6.4+2343
+version: 1.6.5+2344
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
- Place TW zh above zh locale for consistency
- Fix blank search query being blocked on add-app page, restoring ability to list all apps in F-Droid third-party repos (from #3000)
- Add HandshakeException retry with staggered random delays for concurrent TLS failures during batch update checks (#3008)
- Add notification permission request on first non-TV launch and declare POST_NOTIFICATIONS in manifest (#3070)
- Fix download progress not updating on app list tiles because tileChild was computed outside ValueListenableBuilder