### PR TITLE
Fix spacing, source names, and redundant button

### DIFF
--- a/lib/app_sources/coolapk.dart
+++ b/lib/app_sources/coolapk.dart
@@ -17,8 +17,10 @@ import 'package:obtainium/providers/source_provider.dart';
 /// Token generation adapted from https://github.com/XiaoMengXinX/FuckCoolapkTokenV2
 /// and https://github.com/Coolapk-UWP/Coolapk-UWP
 class CoolApk extends AppSource {
+  @override
+  String get name => tr('coolApk');
+
   CoolApk() {
-    name = tr('coolApk');
     hosts = ['coolapk.com'];
     allowSubDomains = true;
     naiveStandardVersionDetection = true;

--- a/lib/app_sources/direct_apk_link.dart
+++ b/lib/app_sources/direct_apk_link.dart
@@ -10,8 +10,10 @@ import 'package:obtainium/providers/source_provider.dart';
 class DirectAPKLink extends AppSource {
   final HTML html = HTML();
 
+  @override
+  String get name => tr('directAPKLink');
+
   DirectAPKLink() {
-    name = tr('directAPKLink');
     versionDetectionDisallowed = true;
     excludeCommonSettingKeys = [
       'versionExtractionRegEx',

--- a/lib/app_sources/fdroid.dart
+++ b/lib/app_sources/fdroid.dart
@@ -13,9 +13,11 @@ import 'package:obtainium/providers/source_provider.dart';
 
 class FDroid extends AppSource {
   static const _maxChangeLogCodeUnits = 2048;
+  @override
+  String get name => tr('fdroid');
+
   FDroid() {
     hosts = ['f-droid.org'];
-    name = tr('fdroid');
     naiveStandardVersionDetection = true;
     canSearch = true;
     inferAppIdFromUrlPath = true;

--- a/lib/app_sources/fdroidrepo.dart
+++ b/lib/app_sources/fdroidrepo.dart
@@ -11,8 +11,10 @@ import 'package:obtainium/providers/source_provider.dart';
 class FDroidRepo extends AppSource {
   bool _appIdFoundInUrl = false;
 
+  @override
+  String get name => tr('fdroidThirdPartyRepo');
+
   FDroidRepo() {
-    name = tr('fdroidThirdPartyRepo');
     canSearch = true;
     includeAdditionalOptsInMainSearch = true;
     neverAutoSelect = true;

--- a/lib/app_sources/huaweiappgallery.dart
+++ b/lib/app_sources/huaweiappgallery.dart
@@ -4,8 +4,10 @@ import 'package:obtainium/custom_errors.dart';
 import 'package:obtainium/providers/source_provider.dart';
 
 class HuaweiAppGallery extends AppSource {
+  @override
+  String get name => tr('huaweiAppGallery');
+
   HuaweiAppGallery() {
-    name = tr('huaweiAppGallery');
     hosts = ['appgallery.huawei.com', 'appgallery.cloud.huawei.com'];
     versionDetectionDisallowed = true;
     showReleaseDateAsVersionToggle = true;

--- a/lib/app_sources/telegramapp.dart
+++ b/lib/app_sources/telegramapp.dart
@@ -5,9 +5,11 @@ import 'package:obtainium/custom_errors.dart';
 import 'package:obtainium/providers/source_provider.dart';
 
 class TelegramApp extends AppSource {
+  @override
+  String get name => tr('telegramApp');
+
   TelegramApp() {
     hosts = ['telegram.org'];
-    name = tr('telegramApp');
   }
 
   @override

--- a/lib/app_sources/tencent.dart
+++ b/lib/app_sources/tencent.dart
@@ -5,8 +5,10 @@ import 'package:obtainium/custom_errors.dart';
 import 'package:obtainium/providers/source_provider.dart';
 
 class Tencent extends AppSource {
+  @override
+  String get name => tr('tencentAppStore');
+
   Tencent() {
-    name = tr('tencentAppStore');
     hosts = ['sj.qq.com'];
     naiveStandardVersionDetection = true;
     showReleaseDateAsVersionToggle = true;

--- a/lib/app_sources/vivoappstore.dart
+++ b/lib/app_sources/vivoappstore.dart
@@ -8,8 +8,10 @@ class VivoAppStore extends AppSource {
   static const appDetailUrl =
       'https://h5coml.vivo.com.cn/h5coml/appdetail_h5/browser_v2/index.html?appId=';
 
+  @override
+  String get name => tr('vivoAppStore');
+
   VivoAppStore() {
-    name = tr('vivoAppStore');
     hosts = ['h5.appstore.vivo.com.cn', 'h5coml.vivo.com.cn'];
     naiveStandardVersionDetection = true;
     canSearch = true;

--- a/lib/pages/add_app.dart
+++ b/lib/pages/add_app.dart
@@ -852,7 +852,7 @@ class AddAppPageState extends State<AddAppPage> {
             child: Padding(
               padding: EdgeInsets.fromLTRB(
                 16,
-                MediaQuery.of(context).padding.top,
+                0,
                 16,
                 MediaQuery.of(context).padding.bottom,
               ),

--- a/lib/pages/apps.dart
+++ b/lib/pages/apps.dart
@@ -323,7 +323,7 @@ class AppsPageState extends State<AppsPage> {
                 [
                   MapEntry('', tr('none')),
                   ...ctx.read<SourceProvider>().sources.map(
-                    (e) => MapEntry(e.name, e.name),
+                    (e) => MapEntry(e.sourceIdentifier, e.name),
                   ),
                 ],
               ),
@@ -1038,6 +1038,7 @@ class AppsPageState extends State<AppsPage> {
   Widget build(BuildContext context) {
     final appsProvider = context.watch<AppsProvider>();
     final settingsProvider = context.watch<SettingsProvider>();
+    final sourceProvider = context.read<SourceProvider>();
 
     if (!appsProvider.loadingApps &&
         appsProvider.apps.isNotEmpty &&
@@ -1128,8 +1129,15 @@ class AppsPageState extends State<AppsPage> {
         }
       }
     } else if (groupBy == GroupByMode.source.name) {
+      final sourceNames = {
+        for (final s in sourceProvider.sources)
+          s.sourceIdentifier: s.name,
+      };
       for (var i = 0; i < listedApps.length; i++) {
-        grouped.putIfAbsent(listedApps[i].sourceType, () => []).add(i);
+        final label = sourceNames[listedApps[i].sourceType] ??
+            listedApps[i].sourceType ??
+            tr('noSource');
+        grouped.putIfAbsent(label, () => []).add(i);
       }
     }
     final listedGroups = grouped.keys.toList();

--- a/lib/pages/import_export.dart
+++ b/lib/pages/import_export.dart
@@ -93,7 +93,7 @@ class _ImportFromURLListPageState extends State<ImportFromURLListPage> {
                   child: Padding(
                     padding: EdgeInsets.fromLTRB(
                       16,
-                      MediaQuery.of(context).padding.top,
+                      0,
                       16,
                       MediaQuery.of(context).padding.bottom,
                     ),

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -267,18 +267,6 @@ class _SettingsPageState extends State<SettingsPage> {
             ),
             IconButton(
               onPressed: () {
-                unawaited(
-                  launchUrlString(
-                    'https://apps.obtainium.imranr.dev/',
-                    mode: LaunchMode.externalApplication,
-                  ),
-                );
-              },
-              icon: const Icon(Icons.apps_rounded),
-              tooltip: tr('crowdsourcedConfigsLabel'),
-            ),
-            IconButton(
-              onPressed: () {
                 context.read<LogsProvider>().get().then((logs) {
                   if (!context.mounted) return;
                   if (logs.isEmpty) {

--- a/lib/providers/apps_provider_lifecycle.dart
+++ b/lib/providers/apps_provider_lifecycle.dart
@@ -275,7 +275,7 @@ extension AppsProviderLifecycle on AppsProvider {
                     app.url,
                     overrideSource: app.overrideSource,
                   );
-                  final sourceType = src.name;
+                  final sourceType = src.sourceIdentifier;
                   // If the app is installed, grab its OS data and reconcile install statuses
                   final PackageInfo? installedInfo = installedAppsMap[app.id];
                   // Reconcile differences between the installed and recorded install info

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: obtainium
 description: Get Android app updates straight from the source.
 publish_to: 'none'
 
-version: 1.6.7+2346
+version: 1.6.8+2347
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
- Remove double top padding on add-app and import-from-URL-list pages:
  content area no longer adds MediaQuery.padding.top since the
  AppBar/SliverAppBar already accounts for system bar insets.

- Fix source names showing raw translation keys in group headers and
  filter dropdown. Eight sources used name = tr(key) in their
  constructor, which resolved before translations loaded at startup.
  Changed to @OverRide String get name => tr(key) so resolution is
  always lazy. Store sourceIdentifier (stable) instead of name in
  AppInMemory.sourceType; resolve to display name at presentation
  time via a lookup map built from SourceProvider.sources.

- Remove redundant crowdsourced-app-configs button from the settings
  page app bar (an ActionChip on the add-app page already provides
  the same link).