### PR TITLE
Begin app installation immediately after each download completes during batch updates

### DIFF
--- a/lib/providers/apps_provider_install.dart
+++ b/lib/providers/apps_provider_install.dart
@@ -13,10 +13,10 @@ import 'package:flutter_fgbg/flutter_fgbg.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:obtainium/components/app_detail_widgets.dart';
 import 'package:obtainium/custom_errors.dart';
+import 'package:obtainium/installers/external_installer.dart';
 import 'package:obtainium/installers/installer.dart';
 import 'package:obtainium/installers/shizuku_installer.dart';
 import 'package:obtainium/installers/stock_installer.dart';
-import 'package:obtainium/installers/external_installer.dart';
 import 'package:obtainium/providers/apps_provider.dart';
 import 'package:obtainium/providers/logs_provider.dart';
 import 'package:obtainium/providers/notifications_provider.dart';
@@ -915,37 +915,64 @@ extension AppsProviderInstall on AppsProvider {
     appsToInstall = moveStrToEnd(appsToInstall, '$obtainiumId.fdroid');
     appsToInstall = moveStrToEnd(appsToInstall, '$obtainiumId.debug');
 
-    List<_InstallResult> downloadResults = [];
+    final List<_InstallResult> obtainiumResults = [];
+    Future<void> installChain = Future.value();
+
+    Future<void> handleAppDownloadAndQueueInstall(String id) async {
+      final res = await _downloadAppForInstall(
+        id,
+        // ignore: use_build_context_synchronously
+        context,
+        notificationsProvider,
+        useExisting,
+        errors,
+      );
+      if (!errors.appIdNames.containsKey(res.id)) {
+        final isObtainium =
+            res.id == obtainiumId ||
+            res.id == obtainiumTempId ||
+            res.id == '$obtainiumId.fdroid' ||
+            res.id == '$obtainiumId.debug';
+        if (isObtainium) {
+          obtainiumResults.add(res);
+        } else {
+          installChain = installChain.then((_) async {
+            try {
+              await _installDownloadedApp(
+                res.id,
+                res.willBeSilent,
+                res.downloadedFile,
+                res.downloadedDir,
+                installedIds,
+                errors,
+                // ignore: use_build_context_synchronously
+                context,
+                notificationsProvider,
+              );
+            } catch (e) {
+              final appId = res.id;
+              errors.add(appId, e, appName: apps[appId]?.name);
+            }
+          });
+        }
+      }
+    }
+
     try {
       // Background tasks (forceParallelDownloads) run serially like main,
       // otherwise the parallelDownloads setting controls concurrency.
       if (forceParallelDownloads || !settingsProvider.parallelDownloads) {
         for (var id in appsToInstall) {
-          downloadResults.add(
-            await _downloadAppForInstall(
-              id,
-              // ignore: use_build_context_synchronously
-              context,
-              notificationsProvider,
-              useExisting,
-              errors,
-            ),
-          );
+          await handleAppDownloadAndQueueInstall(id);
         }
       } else {
-        downloadResults = await Future.wait(
-          appsToInstall.map(
-            (id) => _downloadAppForInstall(
-              id,
-              context,
-              notificationsProvider,
-              useExisting,
-              errors,
-            ),
-          ),
+        await Future.wait(
+          appsToInstall.map((id) => handleAppDownloadAndQueueInstall(id)),
         );
       }
-      for (var res in downloadResults) {
+      await installChain;
+
+      for (var res in obtainiumResults) {
         if (!errors.appIdNames.containsKey(res.id)) {
           try {
             await _installDownloadedApp(


### PR DESCRIPTION
Previously during batch updates, installation would only begin after *all* apps in the batch finished downloading, which was a bit annoying for updates from RuStore where apps are often like 200+ MB. 

This PR updates `downloadAndInstallLatestApps()` so that installation starts as soon as each individual app completes its download, without waiting for the rest of the downloads to finish