### PR TITLE
fix: stop forwarding credentials to cross-origin redirect targets

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -212,6 +212,7 @@
     "installX": "Install {}",
     "installed": "Installed",
     "installedVersionX": "Installed: {}",
+    "insecureRedirect": "Refused to follow a redirect from HTTPS to insecure HTTP",
     "installing": "Installing",
     "intermediateLink": "Intermediate link",
     "intermediateLinkNotFound": "Intermediate link not found",

--- a/lib/providers/source_provider.dart
+++ b/lib/providers/source_provider.dart
@@ -1320,6 +1320,13 @@ class TypedSettings {
 class HttpService {
   static const int maxRedirects = 10;
 
+  /// Headers that must never be forwarded to a different origin on redirect.
+  static const Set<String> sensitiveRedirectHeaders = {
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+  };
+
   HttpClient createHttpClient(bool insecure) {
     final client = HttpClient();
     if (insecure) {
@@ -1328,6 +1335,14 @@ class HttpService {
     }
     return client;
   }
+
+  /// Whether two URIs share the same origin (scheme, host, and port — Dart
+  /// normalizes default ports for http/https, so explicit and implicit
+  /// default ports compare equal).
+  static bool isSameOrigin(Uri a, Uri b) =>
+      a.scheme.toLowerCase() == b.scheme.toLowerCase() &&
+      a.host.toLowerCase() == b.host.toLowerCase() &&
+      a.port == b.port;
 
   String ensureAbsoluteUrl(String ambiguousUrl, Uri referenceAbsoluteUrl) {
     try {
@@ -1377,9 +1392,28 @@ class HttpService {
           (response.statusCode >= 300 && response.statusCode <= 399)) {
         final location = response.headers.value(HttpHeaders.locationHeader);
         if (location != null) {
-          currentUrl = Uri.parse(ensureAbsoluteUrl(location, currentUrl));
+          final nextUrl = Uri.parse(ensureAbsoluteUrl(location, currentUrl));
+          if (currentUrl.scheme == 'https' && nextUrl.scheme == 'http') {
+            // Never follow a redirect that downgrades to cleartext HTTP.
+            httpClient.close();
+            throw ObtainiumError(tr('insecureRedirect'));
+          }
+          if (!isSameOrigin(currentUrl, nextUrl)) {
+            // Do not forward credentials or session cookies to a
+            // different origin.
+            requestHeaders = requestHeaders == null
+                ? null
+                : (Map<String, String>.from(requestHeaders)
+                  ..removeWhere(
+                    (key, _) =>
+                        sensitiveRedirectHeaders.contains(key.toLowerCase()),
+                  ));
+            cookies = [];
+          } else {
+            cookies = response.cookies;
+          }
+          currentUrl = nextUrl;
           redirectCount++;
-          cookies = response.cookies;
           httpClient.close();
           httpClient = null;
           continue;


### PR DESCRIPTION
`HttpService.sourceRequestStreamResponse` follows redirects manually. On
every hop it re-applies the original request headers — including
`Authorization` (e.g. the GitHub PAT sent as `Token …`) and any custom
headers configured for HTML sources — regardless of the redirect target's
origin. Session cookies collected along the way are forwarded the same way.

A source answering `302` to a third-party host therefore receives the
user's credentials. The same loop also follows `https → http` downgrades,
silently dropping to cleartext.

## What this PR changes

In the redirect loop only:

- On a cross-origin redirect (scheme, host or port differs), `Authorization`,
  `Proxy-Authorization` and `Cookie` headers are stripped, and accumulated
  session cookies are not forwarded.
- `https → http` redirects are refused with an error instead of being
  followed.
- Same-origin redirects are unchanged: headers and cookies are kept, so
  legitimate flows (e.g. same-host API redirects) keep working.

## What it deliberately does NOT change

- The APK download path (`downloadFile`), which delegates redirect
  following to `dart:io` and does not re-apply custom headers — verified
  safe.
- No behavior change for same-origin redirects, no new settings, no UI
  besides one new error string (`en.json` only, other locales to follow via
  the usual translation process).

## Tests

Regression tests are ready (cross-origin strip, same-origin keep, downgrade
refusal, plus a control for the download path) and will follow in a
dedicated test PR once this lands — the project has no `flutter_test`
harness yet, and adding it here would mix infrastructure with the fix.