### PR TITLE
Validate file paths in archive extraction and downloads

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -216,6 +216,7 @@
     "intermediateLink": "Intermediate link",
     "intermediateLinkNotFound": "Intermediate link not found",
     "intermediateLinkRegex": "Filter for an 'intermediate' link to visit",
+    "invalidArchive": "Archive contains a file with an unsafe path",
     "invalidInput": "Invalid input",
     "invalidRegEx": "Invalid regular expression",
     "invalidURLForSource": "Not a valid {} app URL",

--- a/lib/providers/apps_provider.dart
+++ b/lib/providers/apps_provider.dart
@@ -432,9 +432,12 @@ Future<File> downloadFile(
   } else if (ext == 'attachment') {
     ext = 'apk';
   }
-  fileName = fileNameHasExt
-      ? fileName
-      : fileName.split('/').last; // Ensure the fileName is a file name
+  // Never trust a source-provided fileName: always reduce it to a plain
+  // basename so it cannot escape destDir, whatever the caller passed.
+  fileName = fileName.replaceAll('\\', '/').split('/').last;
+  if (fileName.isEmpty || fileName == '.' || fileName == '..') {
+    throw ObtainiumError(tr('unexpectedError'));
+  }
   File downloadedFile = File('$destDir/$fileName.$ext');
   if (fileNameHasExt) {
     // If the user says the filename already has an ext, ignore whatever you inferred from above

--- a/lib/providers/apps_provider_install.dart
+++ b/lib/providers/apps_provider_install.dart
@@ -460,14 +460,21 @@ extension AppsProviderInstall on AppsProvider {
     if (!destDir.existsSync()) {
       destDir.createSync(recursive: true);
     }
+    final destRoot = Uri.file(
+      destDir.absolute.path,
+    ).normalizePath().toFilePath();
     for (final file in tarArchive.files) {
-      if (file.isFile) {
-        final content = file.content;
-        final outPath = '${destDir.path}/${file.name}';
-        final outFile = File(outPath);
-        outFile.createSync(recursive: true);
-        outFile.writeAsBytesSync(content);
+      if (!file.isFile) continue;
+      // Reject entries whose path would escape the destination directory.
+      final outPath = Uri.file(
+        '$destRoot/${file.name}',
+      ).normalizePath().toFilePath();
+      if (outPath != destRoot && !outPath.startsWith('$destRoot/')) {
+        throw ObtainiumError(tr('invalidArchive'));
       }
+      final outFile = File(outPath);
+      outFile.createSync(recursive: true);
+      outFile.writeAsBytesSync(file.content);
     }
   }
 


### PR DESCRIPTION
Two file paths built from source-controlled data were not validated:

1. **Tarball extraction** (`extractTarballFile`): tar entry names were used
   verbatim to build the output path. A tarball served by a source (release
   asset, direct link…) containing an entry like `../../x` would be written
   outside the extraction directory. (ZIP extraction is not affected: it
   delegates to `flutter_archive`, whose native code rejects entries
   escaping the destination — verified.)
2. **Asset downloads** (`downloadFile` with `fileNameHasExt = true`, used by
   the "download asset" feature into the shared Download folder): the file
   name comes from the source (e.g. remote link/button text) and was used
   unsanitized, allowing `../` traversal outside the destination directory.

## What this PR changes

Suggested reading order — the commits are independent:

1. **`fix: reject tar entries that escape the extraction directory`** — each
   tar entry's normalized output path must stay within the destination
   directory, otherwise extraction aborts with an error (new `en.json`
   string). Legitimate archives are unaffected.
2. **`fix: always reduce download file names to a plain basename`** — the
   basename sanitization previously applied only when `fileNameHasExt` was
   false now applies unconditionally; empty/`.`/`..` results are rejected.

## What it deliberately does NOT change

- ZIP extraction (already protected by `flutter_archive`'s canonical-path
  check).
- No changes to which files are downloaded or how archives are used after
  extraction; no new settings.
