### PR TITLE
feat: warn before exporting settings that may include secrets

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -58,6 +58,7 @@
     "authorName": "Author/name",
     "autoApkFilterByArch": "Attempt to filter APKs by CPU architecture if possible",
     "autoExportOnChanges": "Automatically export on changes",
+    "exportIncludesSecretsWarning": "The exported file will contain all settings in cleartext, which may include sensitive values such as tokens. Anyone with the file can read them.",
     "exportInstalledOnly": "Export installed apps only",
     "autoLinkFilterByArch": "Attempt to filter links by CPU architecture if possible",
     "autoSelectHighestVersionCode": "Auto-select highest versionCode APK",

--- a/lib/pages/import_export.dart
+++ b/lib/pages/import_export.dart
@@ -15,6 +15,33 @@ import 'package:obtainium/providers/source_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:file_picker/file_picker.dart';
 
+/// Shows a blocking dialog warning that an "include all settings" export
+/// embeds potentially sensitive values in cleartext.
+/// Returns true if the user chooses to export anyway.
+Future<bool> confirmExportIncludesSecrets(BuildContext context) async {
+  final proceed = await showDialog<bool>(
+    context: context,
+    builder: (BuildContext ctx) {
+      return AlertDialog(
+        title: Text(tr('warning')),
+        content: Text(tr('exportIncludesSecretsWarning')),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(tr('cancel')),
+          ),
+          FilledButton.tonal(
+            autofocus: true,
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(tr('continue')),
+          ),
+        ],
+      );
+    },
+  );
+  return proceed == true;
+}
+
 class ImportFromURLListPage extends StatefulWidget {
   const ImportFromURLListPage({super.key});
 
@@ -395,6 +422,10 @@ class _ExportSectionState extends State<ExportSection> {
 
     Future<void> runObtainiumExport({bool pickOnly = false}) async {
       settingsProvider.selectionClick();
+      if (!pickOnly && settingsProvider.exportSettings >= 2) {
+        final proceed = await confirmExportIncludesSecrets(context);
+        if (!proceed) return;
+      }
       unawaited(
         appsProvider
             .export(


### PR DESCRIPTION
When "Include settings" is set to **all**, the exported JSON embeds every
stored setting in cleartext — including source credentials (`github-creds`,
`gitlab-creds`, i.e. personal access tokens). The export flow gives no
indication of this, and the file typically ends up shared or synced to a
cloud service.

## What this PR changes

- Running a manual export while "Include settings" is **all** now shows a
  blocking warning dialog explaining that the file will contain all
  settings in cleartext, which may include sensitive values such as tokens.
  The user can cancel or proceed.
- The message is deliberately generic ("may include sensitive values") so
  it stays accurate regardless of how credentials are stored in the future.

## What it deliberately does NOT change

- The export content itself, the "none"/"excludeSecrets" modes, and the
  auto-export behavior (which the user explicitly opted into).
- One new `en.json` string; other locales via the usual translation
  process.
