### PR TITLE
Restrict WebView navigation and external link schemes

### DIFF
--- a/lib/components/app_list_tile.dart
+++ b/lib/components/app_list_tile.dart
@@ -59,14 +59,9 @@ void showChangeLogDialog(
                   data: changeLog,
                   onTapLink: (text, href, title) {
                     if (href != null) {
-                      unawaited(
-                        launchUrlString(
-                          href.startsWith('http://') ||
-                                  href.startsWith('https://')
-                              ? href
-                              : '${Uri.parse(app.url).origin}/$href',
-                          mode: LaunchMode.externalApplication,
-                        ),
+                      launchExternalUrlSafe(
+                        href,
+                        baseOrigin: Uri.parse(app.url).origin,
                       );
                     }
                   },

--- a/lib/components/ui_widgets.dart
+++ b/lib/components/ui_widgets.dart
@@ -11,6 +11,31 @@ import 'package:obtainium/providers/settings_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
+/// Returns [href] as a launchable external URI, restricted to safe schemes
+/// (http, https, mailto); anything else (javascript:, intent:, file:, …)
+/// yields null. Scheme-less URLs are resolved against [baseOrigin] if given.
+Uri? safeExternalUrl(String href, {String? baseOrigin}) {
+  var uri = Uri.tryParse(href);
+  if (uri == null) return null;
+  if (uri.scheme.isEmpty) {
+    if (baseOrigin == null) return null;
+    uri = Uri.tryParse('$baseOrigin/$href');
+    if (uri == null) return null;
+  }
+  const allowedSchemes = {'http', 'https', 'mailto'};
+  if (!allowedSchemes.contains(uri.scheme.toLowerCase())) return null;
+  return uri;
+}
+
+/// Launches [href] in an external browser if [safeExternalUrl] allows it.
+void launchExternalUrlSafe(String href, {String? baseOrigin}) {
+  final uri = safeExternalUrl(href, baseOrigin: baseOrigin);
+  if (uri == null) return;
+  unawaited(
+    launchUrlString(uri.toString(), mode: LaunchMode.externalApplication),
+  );
+}
+
 Future<void> copyToClipboard(BuildContext context, String text) async {
   await Clipboard.setData(ClipboardData(text: text));
   if (context.mounted) {

--- a/lib/pages/app.dart
+++ b/lib/pages/app.dart
@@ -23,6 +23,13 @@ import 'package:webview_flutter/webview_flutter.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
+/// Whether two URIs share the same origin (scheme, host, and port — Dart
+/// normalizes default ports for http/https).
+bool _isSameOrigin(Uri a, Uri b) =>
+    a.scheme.toLowerCase() == b.scheme.toLowerCase() &&
+    a.host.toLowerCase() == b.host.toLowerCase() &&
+    a.port == b.port;
+
 class AppPage extends StatefulWidget {
   const AppPage({
     super.key,
@@ -180,13 +187,26 @@ class _AppPageState extends State<AppPage> {
                 });
               }
             },
-            onNavigationRequest: (NavigationRequest request) =>
-                !(request.url.startsWith('http://') ||
-                    request.url.startsWith('https://') ||
-                    request.url.startsWith('ftp://') ||
-                    request.url.startsWith('ftps://'))
-                ? NavigationDecision.prevent
-                : NavigationDecision.navigate,
+            onNavigationRequest: (NavigationRequest request) {
+              final uri = Uri.tryParse(request.url);
+              if (uri == null ||
+                  !(uri.isScheme('http') || uri.isScheme('https'))) {
+                return NavigationDecision.prevent;
+              }
+              final sourceUri = Uri.tryParse(url);
+              if (sourceUri != null && !_isSameOrigin(uri, sourceUri)) {
+                // Cross-origin navigations leave the in-app WebView and open
+                // in the external browser instead.
+                unawaited(
+                  launchUrlString(
+                    request.url,
+                    mode: LaunchMode.externalApplication,
+                  ),
+                );
+                return NavigationDecision.prevent;
+              }
+              return NavigationDecision.navigate;
+            },
           ),
         );
       webViewController = wvc;

--- a/lib/pages/app.dart
+++ b/lib/pages/app.dart
@@ -993,9 +993,7 @@ class _AppPageState extends State<AppPage> {
             ),
             onTapLink: (text, href, title) {
               if (href != null) {
-                unawaited(
-                  launchUrlString(href, mode: LaunchMode.externalApplication),
-                );
+                launchExternalUrlSafe(href);
               }
             },
             extensionSet: md.ExtensionSet(


### PR DESCRIPTION
1. **App detail WebView**: the embedded WebView loading the app's source
   page allowed main-frame navigation to any `http(s)` *or* `ftp(s)` URL.
   A source page (or any script on it) could navigate the in-app WebView
   anywhere — e.g. a lookalike phishing page presented inside Obtainium's
   trusted UI.
2. **Markdown links**: changelogs and "about" texts are remote-provided
   markdown. Tapping a link passed the raw `href` to an external `VIEW`
   intent with no scheme validation (`javascript:`, `intent:`, `file:`…).

## What this PR changes

Suggested reading order — the commits are independent:

1. **`fix: keep webview navigation same-origin and http(s)-only`** — the
   navigation delegate now only allows `http`/`https` navigations that stay
   on the source page's origin (scheme/host/port). Cross-origin navigations
   are opened in the external browser instead; `ftp(s)` and non-web schemes
   are blocked. Subresource loads are unaffected.
2. **`fix: only launch safe url schemes from remote markdown`** — new
   `safeExternalUrl` helper (pure, testable) that whitelists
   `http`/`https`/`mailto` and resolves scheme-less URLs against the app
   origin (preserving the existing relative-link behavior for changelogs);
   both markdown `onTapLink` handlers use it.

## What it deliberately does NOT change

- JavaScript remains enabled in the WebView (source pages need it to
  render); the initial source URL load is unchanged.
- No changes to how links are rendered, only to how taps are handled.
