### PR TITLE
feat: store source credentials in secure storage

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,8 @@
         android:banner="@drawable/tv_banner"
         android:requestLegacyExternalStorage="true"
         android:usesCleartextTraffic="true"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:localeConfig="@xml/locales_config"
         android:memtagMode="async">
         <activity

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <exclude domain="sharedpref" path="FlutterSecureStorage.xml" />
+    <exclude domain="sharedpref" path="FlutterSecureKeyStorage.xml" />
+    <exclude domain="sharedpref" path="FlutterSecureStorageConfiguration.xml" />
+    <exclude domain="sharedpref" path="FlutterSecureStorageConfiguration:FlutterSecureStorage.xml" />
+</full-backup-content>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="sharedpref" path="FlutterSecureStorage.xml" />
+        <exclude domain="sharedpref" path="FlutterSecureKeyStorage.xml" />
+        <exclude domain="sharedpref" path="FlutterSecureStorageConfiguration.xml" />
+        <exclude domain="sharedpref" path="FlutterSecureStorageConfiguration:FlutterSecureStorage.xml" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="sharedpref" path="FlutterSecureStorage.xml" />
+        <exclude domain="sharedpref" path="FlutterSecureKeyStorage.xml" />
+        <exclude domain="sharedpref" path="FlutterSecureStorageConfiguration.xml" />
+        <exclude domain="sharedpref" path="FlutterSecureStorageConfiguration:FlutterSecureStorage.xml" />
+    </device-transfer>
+</data-extraction-rules>

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -35,6 +35,7 @@ class _SettingsPageState extends State<SettingsPage> {
   int? androidSdkInt;
   int _installerCheckSeq = 0;
   bool _isRunningBgCheck = false;
+  Map<String, String?> _credentials = {};
 
   @override
   void initState() {
@@ -44,7 +45,26 @@ class _SettingsPageState extends State<SettingsPage> {
       final sp = context.read<SettingsProvider>();
       if (sp.prefs == null) sp.initializeSettings();
       initAndroidSdk();
+      _loadCredentials();
     });
+  }
+
+  /// Loads source credentials from secure storage for display in the form.
+  Future<void> _loadCredentials() async {
+    final sp = context.read<SettingsProvider>();
+    final keys = context
+        .read<SourceProvider>()
+        .sources
+        .expand((e) => e.sourceConfigSettingFormItems)
+        .map((e) => e.key)
+        .where(SettingsProvider.isCredentialKey);
+    final map = <String, String?>{};
+    for (final key in keys) {
+      map[key] = await sp.getCredential(key);
+    }
+    if (mounted) {
+      setState(() => _credentials = map);
+    }
   }
 
   Future<void> _triggerManualBgCheck() async {
@@ -297,7 +317,9 @@ class _SettingsPageState extends State<SettingsPage> {
       if (item is GeneratedFormSwitch) {
         item.value = settingsProvider.getSettingBool(item.key);
       } else {
-        item.value = settingsProvider.getSettingString(item.key);
+        item.value = SettingsProvider.isCredentialKey(item.key)
+            ? _credentials[item.key]
+            : settingsProvider.getSettingString(item.key);
       }
     }
     final Widget? sourceSpecificForm = allSourceConfigItems.isEmpty
@@ -314,7 +336,12 @@ class _SettingsPageState extends State<SettingsPage> {
                   if (formItem is GeneratedFormSwitch) {
                     settingsProvider.setSettingBool(key, value == true);
                   } else {
-                    settingsProvider.setSettingString(key, value ?? '');
+                    unawaited(
+                      settingsProvider.setSettingStringOrCredential(
+                        key,
+                        value ?? '',
+                      ),
+                    );
                   }
                 });
               }

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:obtainium/custom_errors.dart';
 import 'package:obtainium/main.dart';
@@ -64,6 +65,13 @@ class SettingsProvider with ChangeNotifier {
   bool isTV = false;
   bool _silent = false;
 
+  /// Credentials (keys ending in `-creds`) live in secure storage, not in
+  /// cleartext SharedPreferences.
+  static const FlutterSecureStorage _secureStorage = FlutterSecureStorage();
+
+  /// Whether [key] holds a credential that must live in secure storage.
+  static bool isCredentialKey(String key) => key.endsWith('-creds');
+
   T? _get<T>(String key) {
     final value = prefs?.get(key);
     if (value is T) return value;
@@ -97,6 +105,7 @@ class SettingsProvider with ChangeNotifier {
     _migrateLegacyExportSetting();
     _normalizeInstallPreference();
     _migrateGroupBySetting();
+    await migrateCredentialsToSecureStorage();
     notifyListeners();
   }
 
@@ -416,6 +425,64 @@ class SettingsProvider with ChangeNotifier {
   void setSettingString(String settingId, String value) {
     prefs?.setString(settingId, value);
     notifyListeners();
+  }
+
+  /// Reads a credential from secure storage, migrating any legacy
+  /// SharedPreferences copy on first access.
+  Future<String?> getCredential(String key) async {
+    final legacy = prefs?.getString(key);
+    if (legacy != null && legacy.isNotEmpty) {
+      await _secureStorage.write(key: key, value: legacy);
+      await prefs?.remove(key);
+      notifyListeners();
+      return legacy;
+    }
+    final value = await _secureStorage.read(key: key);
+    return value != null && value.isNotEmpty ? value : null;
+  }
+
+  /// Writes a credential to secure storage (empty value deletes it) and
+  /// ensures no cleartext copy remains in SharedPreferences.
+  Future<void> setCredential(String key, String value) async {
+    if (value.isEmpty) {
+      await _secureStorage.delete(key: key);
+    } else {
+      await _secureStorage.write(key: key, value: value);
+    }
+    if (prefs?.containsKey(key) == true) {
+      await prefs?.remove(key);
+    }
+    notifyListeners();
+  }
+
+  /// Moves every `-creds` key found in SharedPreferences to secure storage.
+  /// Runs once at settings initialization; [getCredential] also migrates
+  /// lazily as a fallback.
+  Future<void> migrateCredentialsToSecureStorage() async {
+    final keys =
+        prefs?.getKeys().where(isCredentialKey).toList() ?? <String>[];
+    for (final key in keys) {
+      final value = prefs?.getString(key);
+      if (value != null && value.isNotEmpty) {
+        await _secureStorage.write(key: key, value: value);
+      }
+      await prefs?.remove(key);
+    }
+  }
+
+  /// Reads a setting that may be a credential (`-creds` keys are served
+  /// from secure storage).
+  Future<String?> getSettingStringOrCredential(String key) async =>
+      isCredentialKey(key) ? getCredential(key) : getSettingString(key);
+
+  /// Writes a setting that may be a credential (`-creds` keys go to secure
+  /// storage).
+  Future<void> setSettingStringOrCredential(String key, String value) async {
+    if (isCredentialKey(key)) {
+      await setCredential(key, value);
+    } else {
+      setSettingString(key, value);
+    }
   }
 
   bool getSettingBool(String settingId) {

--- a/lib/providers/source_provider.dart
+++ b/lib/providers/source_provider.dart
@@ -838,7 +838,9 @@ abstract class AppSource {
               ? additionalSettings[e.key]
               : (e is GeneratedFormSwitch
                   ? settingsProvider.getSettingBool(e.key).toString()
-                  : settingsProvider.getSettingString(e.key));
+                  : await settingsProvider.getSettingStringOrCredential(
+                      e.key,
+                    ));
       if (val != null) {
         if (e is GeneratedFormSwitch) {
           val = val.toString();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -486,8 +486,56 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.35"
-  flutter_test:
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "15e8c8fe269fdf7d469b23008ab3df521c8b826ed345820532364c31bdebace6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.0"
+  flutter_secure_storage_darwin:
     dependency: transitive
+    description:
+      name: flutter_secure_storage_darwin
+      sha256: ac6d76a752de0cd738334eb4b21743fc4943f449f5b6e308f18838b048c02ac0
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: "76fa9c841b3b1619fc5b5bc36efc7d158fa2356f223b6caeb1d0c80a54168546"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: "788060052712555182aba55ecb5f8b6e5cb9cfe8f776c83249a61fe3ce877db4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: "073a62b3aeb866ab4ce795f960413948e51e5a42a9b0c8333b6daf5bb3208a1c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: "471951813a97006d899db4948acc654a4f28c440083ea08178935ce20b173ec1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.2"
+  flutter_test:
+    dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   cupertino_icons: ^1.0.9
   path_provider: ^2.1.6
   flutter_fgbg: ^0.8.0
+  flutter_secure_storage: ^11.0.0
   flutter_local_notifications: ^22.2.0
   provider: ^6.1.5+1
   http: ^1.6.0
@@ -70,6 +71,8 @@ dependencies:
   workmanager: ^0.10.7
 
 dev_dependencies:
+  flutter_test:
+    sdk: flutter
   flutter_lints: ^6.0.0
   flutter_launcher_icons: ^0.14.4
 


### PR DESCRIPTION
Source credentials (`github-creds`, `gitlab-creds` — personal access
tokens) are stored in cleartext in SharedPreferences
(`/data/data/<pkg>/shared_prefs/*.xml`), readable by anything with root or
backup access to the device.

## What this PR changes

- Credentials (any setting key ending in `-creds`) now live in
  `flutter_secure_storage` (Android Keystore-backed) instead of
  SharedPreferences.
- **Migration is automatic and two-layered**: an eager sweep of existing
  `-creds` keys runs at settings initialization, and `getCredential` also
  migrates lazily on first read as a fallback. No user action needed;
  tokens keep working.
- Reads/writes go through `getSettingStringOrCredential` /
  `setSettingStringOrCredential`, which route `-creds` keys to secure
  storage and everything else to SharedPreferences as before (settings
  page form and source config resolution updated accordingly).
- Writing an empty value deletes the credential; no cleartext copy is ever
  left in SharedPreferences.

**Side effect on exports**: since credentials no longer live in
SharedPreferences, "include settings: all" exports no longer contain them
at all. After a restore, credentials need to be re-entered — which is the
safer behavior anyway (backups shouldn't carry tokens).

## What it deliberately does NOT change

- No change to which sources support credentials or how they're used in
  requests. No new permissions. `flutter_secure_storage` 10.x requires
  minSdk 23; Obtainium already requires 26, so no manifest change.