### PR TITLE
Fix RuStore 419

### DIFF
--- a/lib/app_sources/rustore.dart
+++ b/lib/app_sources/rustore.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
@@ -7,6 +8,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter_charset_detector/flutter_charset_detector.dart';
 import 'package:http/http.dart';
 import 'package:obtainium/custom_errors.dart';
+import 'package:obtainium/providers/logs_provider.dart';
 import 'package:obtainium/providers/settings_provider.dart';
 import 'package:obtainium/providers/source_provider.dart';
 
@@ -194,6 +196,12 @@ class RuStore extends AppSource {
         ),
       );
       if (response.statusCode != 200) {
+        unawaited(
+          LogsProvider().add(
+            'RuStore: nonce request returned ${response.statusCode}',
+            level: LogLevel.warning,
+          ),
+        );
         return null;
       }
       final decoded = await decodeJsonBody(response.bodyBytes);
@@ -218,7 +226,13 @@ class RuStore extends AppSource {
       }
       final signature = signNonce(nonce);
       return _session = (deviceId: deviceId, signature: signature);
-    } catch (_) {
+    } catch (e) {
+      unawaited(
+        LogsProvider().add(
+          'RuStore: failed to generate secure session: $e',
+          level: LogLevel.warning,
+        ),
+      );
       return null;
     }
   }

--- a/lib/app_sources/rustore.dart
+++ b/lib/app_sources/rustore.dart
@@ -1,11 +1,15 @@
 import 'dart:convert';
+import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:crypto/crypto.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter_charset_detector/flutter_charset_detector.dart';
 import 'package:http/http.dart';
 import 'package:obtainium/custom_errors.dart';
 import 'package:obtainium/providers/source_provider.dart';
+
+typedef _SecureSession = ({String deviceId, String signature});
 
 class RuStore extends AppSource {
   RuStore() {
@@ -21,16 +25,42 @@ class RuStore extends AppSource {
       'https://backapi.rustore.ru/applicationData/overallInfo';
   static const String _downloadLinkUrl =
       'https://backapi.rustore.ru/v3/showcase/apps/download-link';
+  static const String _nonceUrl = 'https://api.rustore.ru/v1/secure/nonce';
+
+  // Extracted key from RuStore native. Seems to be static across versions.
+  static final List<int> _hmacKey = base64Decode(
+    'K+eeiCbnVFnZ71KEVal0g5siHaX6v6drh8upeLgEPoU=',
+  );
+  static final List<int> _apkCertSha256 = base64Decode(
+    'Zh8ggo73gN4LebxZ8mowhkMWNV8w5Pkc+hSiB5GDmRQ=',
+  );
+
+  static const String _deviceManufacturer = 'Google';
+  static const String _deviceModelName = 'Pixel 8 Pro';
+  static const String _deviceHardware = 'husky';
+  static const String _firmwareVer = '16';
+  static const String _androidSdkVer = '36';
+  static const String _firmwareLang = 'ru';
+  static const String _ruStoreVerCode = '1105002';
+  static const String _userAgent =
+      'RuStore/1.105.0.2 (Android $_firmwareVer; SDK $_androidSdkVer; '
+      'arm64-v8a; $_deviceManufacturer $_deviceModelName; $_firmwareLang)';
+
+  static _SecureSession? _session;
 
   @override
   Future<Map<String, String>?> getRequestHeaders(
-      Map<String, dynamic> additionalSettings,
-      String url, {
-        bool forAPKDownload = false,
-      }) async {
-    return {
-      'ruStoreVerCode': '1105002',
-    };
+    Map<String, dynamic> additionalSettings,
+    String url, {
+    bool forAPKDownload = false,
+  }) async {
+    final needsSignature =
+        url.startsWith(_appInfoUrl) || url.startsWith(_downloadLinkUrl);
+    final session = needsSignature ? await _getSecureSession() : _session;
+    return _deviceHeaders(
+      deviceId: session?.deviceId,
+      signature: needsSignature ? session?.signature : null,
+    );
   }
 
   @override
@@ -61,7 +91,7 @@ class RuStore extends AppSource {
       if (appId == null) {
         throw NoReleasesError();
       }
-      final Response overallInfoResponse = await sourceRequest(
+      final Response overallInfoResponse = await _sourceRequestWithSessionRetry(
         '$_appInfoUrl/$appId',
         additionalSettings,
       );
@@ -87,13 +117,16 @@ class RuStore extends AppSource {
         relDate = DateTime.tryParse(dateStr);
       }
 
-      final Response downloadLinksResponse = await sourceRequest(
-        _downloadLinkUrl,
-        additionalSettings,
-        followRedirects: false,
-        postBody: {'appId': appDetails['appId'], 'firstInstall': true},
+      final Response downloadLinksResponse =
+          await _sourceRequestWithSessionRetry(
+            _downloadLinkUrl,
+            additionalSettings,
+            followRedirects: false,
+            postBody: {'appId': appDetails['appId'], 'firstInstall': true},
+          );
+      final downloadDetails = await decodeJsonBody(
+        downloadLinksResponse.bodyBytes,
       );
-      final downloadDetails = await decodeJsonBody(downloadLinksResponse.bodyBytes);
       if (downloadLinksResponse.statusCode != 200 || downloadDetails == null) {
         throw getObtainiumHttpError(downloadLinksResponse);
       }
@@ -107,7 +140,7 @@ class RuStore extends AppSource {
 
       return APKDetails(
         version,
-        // RuStore returns a .zip URL for what is actually an APK.
+        // RuStore has an .apk beside the .zip container
         getApkUrlsFromUrls([url.replaceAll(RegExp(r'\.zip$'), '.apk')]),
         AppNames(author, appName),
         releaseDate: relDate,
@@ -116,5 +149,108 @@ class RuStore extends AppSource {
     } catch (e) {
       rethrowOrWrapError(e);
     }
+  }
+
+  Map<String, String> _deviceHeaders({String? deviceId, String? signature}) => {
+    'deviceId': ?deviceId,
+    'firmwareVer': _firmwareVer,
+    'androidSdkVer': _androidSdkVer,
+    'deviceManufacturerName': _deviceManufacturer,
+    'deviceModelName': _deviceModelName,
+    'deviceModel': '$_deviceManufacturer $_deviceModelName',
+    'firmwareLang': _firmwareLang,
+    'ruStoreVerCode': _ruStoreVerCode,
+    'deviceType': 'mobile',
+    'User-Agent': _userAgent,
+    'X-Client-Signature': ?signature,
+  };
+
+  Future<_SecureSession?> _getSecureSession() async =>
+      _session ??= await _generateSecureSession();
+
+  Future<_SecureSession?> _generateSecureSession() async {
+    Future<String?> fetchNonce(String deviceId) async {
+      final response = await post(
+        Uri.parse(_nonceUrl),
+        headers: _deviceHeaders(deviceId: deviceId),
+      );
+      if (response.statusCode != 200) {
+        return null;
+      }
+      final decoded = await decodeJsonBody(response.bodyBytes);
+      return decoded is Map ? decoded['nonce'] as String? : null;
+    }
+
+    // signature = base64(HMAC-SHA256(KEY, base64decode(nonce) || certSha256))
+    String signNonce(String nonceB64) {
+      final nonce = base64Decode(nonceB64);
+      final digest = Hmac(
+        sha256,
+        _hmacKey,
+      ).convert(Uint8List.fromList([...nonce, ..._apkCertSha256]));
+      return base64Encode(digest.bytes);
+    }
+
+    try {
+      final deviceId = _randomDeviceId();
+      final nonce = await fetchNonce(deviceId);
+      if (nonce == null) {
+        return null;
+      }
+      final signature = signNonce(nonce);
+      return _session = (deviceId: deviceId, signature: signature);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  String _randomDeviceId() {
+    int i32(int x) => ((x + 0x80000000) & 0xFFFFFFFF) - 0x80000000;
+    int javaStringHashCode(String s) {
+      var h = 0;
+      for (final ch in s.codeUnits) {
+        h = (31 * h + ch) & 0xFFFFFFFF;
+      }
+      return h >= 0x80000000 ? h - 0x100000000 : h;
+    }
+
+    String deviceIdSuffix() {
+      final m = javaStringHashCode(_deviceManufacturer);
+      final mo = javaStringHashCode(_deviceModelName);
+      final h = javaStringHashCode(_deviceHardware);
+      final d = javaStringHashCode(_deviceHardware);
+      return i32(d + i32((h + i32((mo + i32(m * 31)) * 31)) * 31)).toString();
+    }
+
+    final random = Random();
+    final androidId = List.generate(
+      8,
+      (_) => random.nextInt(256).toRadixString(16).padLeft(2, '0'),
+    ).join();
+    return '$androidId-${deviceIdSuffix()}';
+  }
+
+  /// [sourceRequest] with 419 (session rejected/missing) handling
+  Future<Response> _sourceRequestWithSessionRetry(
+    String url,
+    Map<String, dynamic> additionalSettings, {
+    bool followRedirects = true,
+    Object? postBody,
+  }) async {
+    var response = await sourceRequest(
+      url,
+      additionalSettings,
+      followRedirects: followRedirects,
+      postBody: postBody,
+    );
+    if (response.statusCode == 419 && await _generateSecureSession() != null) {
+      response = await sourceRequest(
+        url,
+        additionalSettings,
+        followRedirects: followRedirects,
+        postBody: postBody,
+      );
+    }
+    return response;
   }
 }

--- a/lib/app_sources/rustore.dart
+++ b/lib/app_sources/rustore.dart
@@ -7,6 +7,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter_charset_detector/flutter_charset_detector.dart';
 import 'package:http/http.dart';
 import 'package:obtainium/custom_errors.dart';
+import 'package:obtainium/providers/settings_provider.dart';
 import 'package:obtainium/providers/source_provider.dart';
 
 typedef _SecureSession = ({String deviceId, String signature});
@@ -47,6 +48,16 @@ class RuStore extends AppSource {
       'arm64-v8a; $_deviceManufacturer $_deviceModelName; $_firmwareLang)';
 
   static _SecureSession? _session;
+  static String? _deviceType;
+
+  Future<String> _getDeviceType() async {
+    if (_deviceType == null) {
+      final settingsProvider = SettingsProvider();
+      await settingsProvider.initializeSettings();
+      _deviceType = settingsProvider.isTV ? 'TV' : 'mobile';
+    }
+    return _deviceType!;
+  }
 
   @override
   Future<Map<String, String>?> getRequestHeaders(
@@ -58,6 +69,7 @@ class RuStore extends AppSource {
         url.startsWith(_appInfoUrl) || url.startsWith(_downloadLinkUrl);
     final session = needsSignature ? await _getSecureSession() : _session;
     return _deviceHeaders(
+      deviceType: await _getDeviceType(),
       deviceId: session?.deviceId,
       signature: needsSignature ? session?.signature : null,
     );
@@ -151,7 +163,11 @@ class RuStore extends AppSource {
     }
   }
 
-  Map<String, String> _deviceHeaders({String? deviceId, String? signature}) => {
+  Map<String, String> _deviceHeaders({
+    required String deviceType,
+    String? deviceId,
+    String? signature,
+  }) => {
     'deviceId': ?deviceId,
     'firmwareVer': _firmwareVer,
     'androidSdkVer': _androidSdkVer,
@@ -160,7 +176,7 @@ class RuStore extends AppSource {
     'deviceModel': '$_deviceManufacturer $_deviceModelName',
     'firmwareLang': _firmwareLang,
     'ruStoreVerCode': _ruStoreVerCode,
-    'deviceType': 'mobile',
+    'deviceType': deviceType,
     'User-Agent': _userAgent,
     'X-Client-Signature': ?signature,
   };
@@ -172,7 +188,10 @@ class RuStore extends AppSource {
     Future<String?> fetchNonce(String deviceId) async {
       final response = await post(
         Uri.parse(_nonceUrl),
-        headers: _deviceHeaders(deviceId: deviceId),
+        headers: _deviceHeaders(
+          deviceType: await _getDeviceType(),
+          deviceId: deviceId,
+        ),
       );
       if (response.statusCode != 200) {
         return null;


### PR DESCRIPTION
Added RuStore "secure session" (device info + X-Client-Signature) generation, using the key extracted from RuStore apk. The API now requires this and rejects >90% of requests without it.

Used device info from Pixel 8 Pro, Android id is randomized, session is cached in memory.