### PR TITLE
docs: Initial documentation for Contributing policies and procedures

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Verification info:
   - Note: The above signature is also valid for the F-Droid flavour of Obtainium, thanks to [reproducible builds](https://f-droid.org/docs/Reproducible_Builds/).
 - [PGP Public Key](https://keyserver.ubuntu.com/pks/lookup?search=contact%40imranr.dev&fingerprint=on&op=index) (to verify APK hashes)
 
+## Contributing / Developing
+
+Please see the pertinent documentation, [on contributing](docs/CONTRIBUTING.md) and [the developer guide](docs/DEVELOPER_GUIDE.md) (architecture description).
+
 ## Limitations
 - For some sources, data is gathered using Web scraping and can easily break due to changes in website design. In such cases, more reliable methods may be unavailable.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to Obtanium!
+
+Policies and procedures on contributing to Obtanium.
+
+## AI Policy
+
+AI use is acceptable, only if you are able to audit the code. This means that you must understand the code that is generated. Please ensure that any AI generated code is also sufficiently tested.
+
+## Bug Reports / Testing
+
+Welcomed!
+
+If you want to be excellent, please consider implementing this guide, [The Art Of The Bug Report](https://www.ministryoftesting.com/insights/11b82aee), when writing bug reports.
+
+And for any testers out there [How to think like a Tester](https://medium.com/@blakenorrish/how-to-think-like-a-tester-7a174ff6aeaf) is a good introduction.
+
+## Development
+
+Please see the [developer guide](docs/DEVELOPER_GUIDE.md) for in-depth details about Obtanium's architecture. Please also update this when making relevant changes.
+
+It is encouraged that all commits have their signature verified, that is signed. 
+Please see the [relevant GitHub documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification); this links to SSH key signing, but other signing is acceptable.
+
+### Logging
+
+Please use our [AppLogger](lib/core/logging/app_logger.dart) for any internal logging.
+
+There are plenty of examples of it's use in [main.dart](lib/main.dart).
+
+### Style
+
+#### Bracing
+
+Please use the "K&R" bracing style. 
+
+```Kotlin
+override fun onCreate(savedInstanceState: Bundle?) {
+    intent?.let {
+        setIntent(transformShareIntent(it))
+    }
+    super.onCreate(savedInstanceState)
+}
+```
+
+#### Indentation
+
+Obtanium is a mixed spacing project; tabs are **not** used. Files will use either four or two spaces as indentation. Please follow the spacing in the current file. New files should use 4 spaces.
+
+## Translations / i18n
+
+User shown text strings are located in `*.json` files in [assets/translations](assets/translations). 
+The main template file is [en.json](assets/translations/en.json). At a minimum please add english translations for any new strings to this file.
+
+[standardize.mjs](assets/translations/standardize.mjs) and MTL may be used as a first pass to add translations for other languages, until more apt translations are proposed.
+
+Please also follow the [indentation style](#indentation).


### PR DESCRIPTION
An initial pass at developing procedures and policies for contributing developers.

[Here](https://github.com/master-bob/Obtainium/blob/contributing/docs/CONTRIBUTING.md) is how it renders.

Feedback and contributions welcome.