### PR TITLE
Point README at the new Deep Links wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Obtainium allows you to install and update apps directly from their releases pag
 
 More info:
 - [Obtainium Wiki](https://wiki.obtainium.imranr.dev/) ([repository](https://github.com/ImranR98/Obtainium-Wiki))
+- [Deep Links](https://wiki.obtainium.imranr.dev/deep_links/) - link straight to an import, or add a badge to your own project
 - [Obtainium 101](https://www.youtube.com/watch?v=0MF_v2OBncw) - Tutorial video
 - ["Verified Apps"](https://github.com/privacyguides/verified-apps-android) - App verification tool (recommended, integrates with Obtainium)
 - [apps.obtainium.imranr.dev](https://apps.obtainium.imranr.dev/) - Crowdsourced app configurations ([repository](https://github.com/ImranR98/apps.obtainium.imranr.dev))


### PR DESCRIPTION
One line in the More info list, pointing at a new Deep Links page on the wiki (companion PR: https://github.com/ImranR98/wiki.obtainium.imranr.dev/pull/17) that documents the obtainium:// scheme.