### PR TITLE
fix: GitHub app releases not obtaining with certificate pinning enabled

### DIFF
--- a/lib/providers/source_provider.dart
+++ b/lib/providers/source_provider.dart
@@ -1341,6 +1341,15 @@ class HttpService {
     'github.com': _loadCertificateFromAsset([
       'assets/ca-certs/sectigo-pub-serv-auth-r46.crt',
       'assets/ca-certs/sectigo-pub-serv-auth-e46.crt',
+
+      // redirects from api.github.com for obtaining release assets point to
+      // release-assets.githubusercontent.com which uses ISRG (Let's Encrypt)
+      // adding that as another section doesn't work because of
+      // HttpClient follows redirects (as intended)
+      'assets/ca-certs/isrg-root-x1.crt',
+      'assets/ca-certs/isrg-root-x2.crt',
+      'assets/ca-certs/isrg-root-ye.crt',
+      'assets/ca-certs/isrg-root-yr.crt',
     ]),
     'codeberg.org': _loadCertificateFromAsset([
       'assets/ca-certs/isrg-root-x1.crt',


### PR DESCRIPTION
Closes #3262

App releases on GitHub obtained via `release-assets.githubusercontent.com` domain which is part of GitHub.
Used CA: ISRG (Let's Encrypt) see [records on bgp.he.net](https://bgp.he.net/dns/release-assets.githubusercontent.com#_SearchTab).
`crt.sh` would proof that too [but it currently down](https://community.letsencrypt.org/t/crt-sh-seems-down/250561)

This fix adds trusting ISRG (Let's Encrypt) for connections initiated to `github.com` which will redirect to `release-assets.githubusercontent.com` for obtaining artifacts from releases section