### PR TITLE
ci: Harden Github Actions by Pinning Version to SHA

### DIFF
--- a/.github/workflows/fastlane.yml
+++ b/.github/workflows/fastlane.yml
@@ -11,6 +11,6 @@ jobs:
   go:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Validate Fastlane Supply Metadata
-        uses: ashutoshgngwr/validate-fastlane-supply-metadata@v2
+        uses: ashutoshgngwr/validate-fastlane-supply-metadata@c8857fdbbd3e00f9a5cbe8604bcecfa95ce8fef8 # v2.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           channel: stable
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
         with:
           distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '21'
@@ -59,19 +59,19 @@ jobs:
           ls -l ./build/app/outputs/flutter-apk/
 
       - name: Save Unsigned APKs as Action Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           path: build/app/outputs/flutter-apk/*
 
       - name: Create Tag
-        uses: mathieudutour/github-tag-action@v6.1
+        uses: mathieudutour/github-tag-action@fcfbdceb3093f6d85a3b194740f8c6cec632f4e2 # v6.1
         with:
           github_token: ${{ secrets.GH_ACCESS_TOKEN }}
           custom_tag: "${{ steps.extract_version.outputs.tag }}"
           tag_prefix: ""
       
       - name: Create Draft Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           tag: "${{ steps.extract_version.outputs.tag }}"

--- a/.github/workflows/translation-validate.yaml
+++ b/.github/workflows/translation-validate.yaml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Pin all actions to an individual commit via a SHA; using a version number is mutable. This has been exploited already, see https://github.com/advisories/GHSA-mrrh-fwg8-r2c3.

Used the following tool: https://github.com/mheap/pin-github-action

