### PR TITLE
Handle missing document picker and revoked export-dir grants gracefully (#3227), Give TV app list more bottom clearance and stop auto-focusing the add button (#3228), Replace dead share action with copy-to-clipboard in log viewer on TV (#3235), Stop WorkManager periodic runs when background update checks are disabled (#3272), Expose zip APK filter option for Direct APK Link and HTML sources (#3278)

### DIFF
--- a/lib/app_sources/direct_apk_link.dart
+++ b/lib/app_sources/direct_apk_link.dart
@@ -43,6 +43,14 @@ class DirectAPKLink extends AppSource {
         value: 'partialAPKHash',
       ),
     ],
+    [
+      GeneratedFormTextField(
+        'zippedApkFilterRegEx',
+        label: tr('zippedApkFilterRegEx'),
+        required: false,
+        additionalValidators: [(value) => regExValidator(value)],
+      ),
+    ],
   ];
 
   @override

--- a/lib/app_sources/html.dart
+++ b/lib/app_sources/html.dart
@@ -284,6 +284,14 @@ class HTML extends AppSource {
         value: 'partialAPKHash',
       ),
     ],
+    [
+      GeneratedFormTextField(
+        'zippedApkFilterRegEx',
+        label: tr('zippedApkFilterRegEx'),
+        required: false,
+        additionalValidators: [(value) => regExValidator(value)],
+      ),
+    ],
   ];
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -195,20 +195,40 @@ class _ObtainiumState extends State<Obtainium> {
   var _firstRunHandled = false;
   var _launchByNotifChecked = false;
   Locale? _lastLocale;
+  SettingsProvider? _settingsProvider;
+  int? _lastSyncedUpdateInterval;
 
-  Future<void> _scheduleWorkManager() async {
-    await Workmanager().registerPeriodicTask(
-      _workManagerTaskName,
-      _workManagerTaskName,
-      frequency: const Duration(minutes: 15),
-      constraints: Constraints(
-        networkType: NetworkType.connected,
-        requiresBatteryNotLow: false,
-        requiresDeviceIdle: false,
-        requiresStorageNotLow: false,
-      ),
-      existingWorkPolicy: ExistingPeriodicWorkPolicy.keep,
-    );
+  Future<void> _syncWorkManager() async {
+    final settingsProvider = _settingsProvider;
+    if (settingsProvider == null) return;
+    final updateInterval = settingsProvider.updateInterval;
+    _lastSyncedUpdateInterval = updateInterval;
+    if (updateInterval <= 0) {
+      // The user disabled background update checks: drop the periodic task so
+      // the OS doesn't keep waking Obtainium for a check that would be skipped.
+      await Workmanager().cancelByUniqueName(_workManagerTaskName);
+    } else {
+      await Workmanager().registerPeriodicTask(
+        _workManagerTaskName,
+        _workManagerTaskName,
+        frequency: const Duration(minutes: 15),
+        constraints: Constraints(
+          networkType: NetworkType.connected,
+          requiresBatteryNotLow: false,
+          requiresDeviceIdle: false,
+          requiresStorageNotLow: false,
+        ),
+        existingWorkPolicy: ExistingPeriodicWorkPolicy.update,
+      );
+    }
+  }
+
+  void _onSettingsChanged() {
+    final settingsProvider = _settingsProvider;
+    if (settingsProvider != null &&
+        settingsProvider.updateInterval != _lastSyncedUpdateInterval) {
+      unawaited(_syncWorkManager());
+    }
   }
 
   void _handleFirstRun(
@@ -277,10 +297,12 @@ class _ObtainiumState extends State<Obtainium> {
       final settingsProvider = context.read<SettingsProvider>();
       await settingsProvider.initializeSettings();
       if (!mounted) return;
+      _settingsProvider = settingsProvider;
+      settingsProvider.addListener(_onSettingsChanged);
       final appsProvider = context.read<AppsProvider>();
       final notifs = context.read<NotificationsProvider>();
 
-      unawaited(_scheduleWorkManager());
+      unawaited(_syncWorkManager());
       _handleFirstRun(settingsProvider, appsProvider, context);
 
       if (!_launchByNotifChecked) {
@@ -288,6 +310,12 @@ class _ObtainiumState extends State<Obtainium> {
         unawaited(notifs.checkLaunchByNotif());
       }
     });
+  }
+
+  @override
+  void dispose() {
+    _settingsProvider?.removeListener(_onSettingsChanged);
+    super.dispose();
   }
 
   @override

--- a/lib/pages/apps.dart
+++ b/lib/pages/apps.dart
@@ -1256,7 +1256,8 @@ class AppsPageState extends State<AppsPage> {
                   ),
                   SliverToBoxAdapter(
                     child: SizedBox(
-                      height: MediaQuery.of(context).padding.bottom + 96,
+                      height: MediaQuery.of(context).padding.bottom +
+                          (settingsProvider.isTV ? 160 : 96),
                     ),
                   ),
                   if (settingsProvider.isTV)
@@ -1265,14 +1266,10 @@ class AppsPageState extends State<AppsPage> {
                         padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
                         child: SizedBox(
                           width: double.infinity,
-                          child: Focus(
-                            autofocus: true,
-                            child: FilledButton.tonalIcon(
-                              onPressed: () =>
-                                  NavHelper.pushAddAppPage(context),
-                              icon: const Icon(Icons.add),
-                              label: Text(tr('addApp')),
-                            ),
+                          child: FilledButton.tonalIcon(
+                            onPressed: () => NavHelper.pushAddAppPage(context),
+                            icon: const Icon(Icons.add),
+                            label: Text(tr('addApp')),
                           ),
                         ),
                       ),

--- a/lib/pages/logs.dart
+++ b/lib/pages/logs.dart
@@ -80,12 +80,23 @@ class _LogsPageState extends State<LogsPage> {
     await _loadLogs(_days);
   }
 
+  void _copyLogs() {
+    unawaited(copyToClipboard(context, _joinLogs()));
+  }
+
   void _shareLogs() {
-    unawaited(
-      SharePlus.instance.share(
-        ShareParams(text: _joinLogs(), subject: tr('appLogs')),
-      ),
-    );
+    unawaited(() async {
+      try {
+        await SharePlus.instance.share(
+          ShareParams(text: _joinLogs(), subject: tr('appLogs')),
+        );
+      } catch (e, s) {
+        AppLogger.error(e, stackTrace: s, message: 'Failed to share logs');
+        if (mounted) {
+          await copyToClipboard(context, _joinLogs());
+        }
+      }
+    }());
   }
 
   Color _levelColor(BuildContext context, AppLogLevel level) {
@@ -132,11 +143,14 @@ class _LogsPageState extends State<LogsPage> {
   );
 
   /// A single M3 Expressive floating toolbar that consolidates navigation
-  /// (jump to top/bottom) and actions (filter, share, clear) into one pill,
-  /// rather than scattering them across the app bar and multiple FABs.
+  /// (jump to top/bottom) and actions (filter, share/copy, clear) into one
+  /// pill, rather than scattering them across the app bar and multiple FABs.
+  /// Android TV has no share sheet, so the share action is replaced with a
+  /// copy-to-clipboard action there.
   Widget _buildFloatingToolbar(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final hasLogs = _logs.isNotEmpty;
+    final isTV = context.read<SettingsProvider>().isTV;
     return Material(
       elevation: 3,
       color: cs.surfaceContainer,
@@ -171,16 +185,28 @@ class _LogsPageState extends State<LogsPage> {
                   )
                   .toList(),
             ),
-            IconButton(
-              onPressed: hasLogs
-                  ? () {
-                      context.read<SettingsProvider>().selectionClick();
-                      _shareLogs();
-                    }
-                  : null,
-              icon: const Icon(Icons.share_rounded),
-              tooltip: tr('share'),
-            ),
+            if (isTV)
+              IconButton(
+                onPressed: hasLogs
+                    ? () {
+                        context.read<SettingsProvider>().selectionClick();
+                        _copyLogs();
+                      }
+                    : null,
+                icon: const Icon(Icons.copy_rounded),
+                tooltip: tr('copyToClipboard'),
+              )
+            else
+              IconButton(
+                onPressed: hasLogs
+                    ? () {
+                        context.read<SettingsProvider>().selectionClick();
+                        _shareLogs();
+                      }
+                    : null,
+                icon: const Icon(Icons.share_rounded),
+                tooltip: tr('share'),
+              ),
             IconButton(
               onPressed: hasLogs
                   ? () {

--- a/lib/providers/apps_provider_import_export.dart
+++ b/lib/providers/apps_provider_import_export.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:easy_localization/easy_localization.dart';
 
 import 'package:obtainium/custom_errors.dart';
+import 'package:obtainium/core/logging/app_logger.dart';
 
 import 'package:obtainium/providers/apps_provider.dart';
 import 'package:obtainium/providers/settings_provider.dart';
@@ -66,6 +67,11 @@ extension AppsProviderImportExport on AppsProvider {
         return null;
       }
       if (exportDir == null) {
+        if (settingsProvider.prefs?.getString('exportDir') != null) {
+          AppLogger.info(
+            'Auto-export skipped: export directory permission unavailable',
+          );
+        }
         return null;
       }
       final files = await saf

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -657,6 +657,12 @@ class SettingsProvider with ChangeNotifier {
     final currentOneWayDataSyncDir = await getExportDir();
     Uri? newOneWayDataSyncDir;
     if (!remove) {
+      // Some devices (e.g. certain Android TV boxes) have no activity that
+      // handles ACTION_OPEN_DOCUMENT_TREE; check first so the user gets a
+      // clear message instead of a raw platform exception.
+      if ((await saf.canOpenDocumentTree()) != true) {
+        throw ObtainiumError(tr('noFilePickerAvailable'));
+      }
       try {
         newOneWayDataSyncDir = (await saf.openDocumentTree());
       } catch (e) {
@@ -676,7 +682,16 @@ class SettingsProvider with ChangeNotifier {
     }
     for (var e in existingSAFPerms) {
       if (e.uri != newOneWayDataSyncDir) {
-        await saf.releasePersistableUriPermission(e.uri);
+        try {
+          await saf.releasePersistableUriPermission(e.uri);
+        } catch (err) {
+          // The grant may have already been revoked (e.g. by the OS after an
+          // app update); releasing it is best-effort cleanup only.
+          AppLogger.error(
+            err,
+            message: 'Failed to release stale URI permission',
+          );
+        }
       }
     }
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: android_file_picker
-      sha256: "1f111ed6bb33724ba782cc86357e3fd97f57051d55fc61adf33dcfc5049a1581"
+      sha256: "0d84bb91fb78af33756107f00cf71ee084474169d481b882b335c3006077a913"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.1.0"
   android_intent_plus:
     dependency: "direct main"
     description:
@@ -240,10 +240,10 @@ packages:
     dependency: transitive
     description:
       name: cupertino_ui
-      sha256: "2137c0d41f3b62cc4d3d2495e6c354bd6b6133cd21c6bb155736cc31dbd49a11"
+      sha256: e9dfe7fac704028f8928cbe4028a0be5e8a709498e8daf8247de99e99a32aef3
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   dbus:
     dependency: transitive
     description:
@@ -336,42 +336,42 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: b7acb5d123cb398f6b4a8a38e43777545254f8fc1fabef3ee11cbbb56aece9c8
+      sha256: "0631f51bbc2e1184bdc9e79384db158dc7830e15b3001feeca700e86563f4d24"
       url: "https://pub.dev"
     source: hosted
-    version: "12.1.2"
+    version: "12.2.0"
   file_picker_darwin:
     dependency: transitive
     description:
       name: file_picker_darwin
-      sha256: "6e7cae501d48fd57a27911608db718ebd898e6ccf934bf09e33a8c0d0365bec0"
+      sha256: "5c32c9400f5c8976c9dd7aa34693c7d2f0c853c28704a1c1409029cb760f5251"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.1.0"
   file_picker_linux:
     dependency: transitive
     description:
       name: file_picker_linux
-      sha256: f0f01ed42967b7355f6f25c8b121ea531d1948e2a9b4b44f4b4de8489d7b04ae
+      sha256: bd52ff1e0048f29df95f913c55ad2991c72791d93e6c42241912c4bdee946cb9
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
   file_picker_platform_interface:
     dependency: transitive
     description:
       name: file_picker_platform_interface
-      sha256: "11ef1b5c14d9186b4788cc273dd8d5cb81bca847145060991a28234ff7916fc1"
+      sha256: d35d8cb68446fae921335bb61501d66cb2469d74c8f3103b8c6ccdbe3fe5afd8
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.3.0"
   file_picker_web:
     dependency: transitive
     description:
       name: file_picker_web
-      sha256: df472142f63c4557fdfbb375c81454ca1c251491069eefcdc6a866bc12f8750b
+      sha256: "935560a9d29fa6f006f2855addebb88e88d438e13627d4cc24187033c106f227"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.1.0"
   fixnum:
     dependency: transitive
     description:
@@ -384,18 +384,18 @@ packages:
     dependency: "direct main"
     description:
       name: flex_color_picker
-      sha256: a0979dd61f21b634717b98eb4ceaed2bfe009fe020ce8597aaf164b9eeb57aaa
+      sha256: f3cac22c1d5af8b355faa9a8146ae81b441664d499475c7a2690c933cf1c673e
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.0"
+    version: "4.0.0"
   flex_seed_scheme:
     dependency: transitive
     description:
       name: flex_seed_scheme
-      sha256: a3183753bbcfc3af106224bff3ab3e1844b73f58062136b7499919f49f3667e7
+      sha256: "08f9ee11f9a08c2dee76d0a07ea824c8a09ea4db9456e32ac4f6dfb34d28392c"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "5.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -636,10 +636,10 @@ packages:
     dependency: transitive
     description:
       name: jni_flutter
-      sha256: "7b717011ea40d04fd47c2731d3d1d36eb99eba3435c2753d62489e8c3c9991d5"
+      sha256: b2310cdd4c18c65c081ab141a41efa94aa26c65431803703ece51996f174f351
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   jni_util:
     dependency: transitive
     description:
@@ -692,10 +692,10 @@ packages:
     dependency: "direct main"
     description:
       name: logger
-      sha256: "25aee487596a6257655a1e091ec2ae66bc30e7af663592cc3a27e6591e05035c"
+      sha256: "2a0dc097e7b01d942475bdd552356db2d0f768b05540bd4b2b53f1840f2239a7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.0"
+    version: "2.8.0"
   logging:
     dependency: transitive
     description:
@@ -732,10 +732,10 @@ packages:
     dependency: transitive
     description:
       name: material_ui
-      sha256: "7ba1ca315d50a004791dbab290417c52a61466d56db2822fe3c5c2994903110c"
+      sha256: "9c0156b0cf8b3f56d365c8ffe051a720be3cae9eec55119f01e01b986ffb7101"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   meta:
     dependency: transitive
     description:
@@ -844,18 +844,18 @@ packages:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: e7317eb2eb611d1bf0386b6b974be9c50449f975f19a90a7b8ea013550302b30
+      sha256: e6bcecadfe40df6b888141f23cbaf6ba6c3da49fb33f6ff887d060dd48544fbd
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.1"
+    version: "13.0.2"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: d7676c6fcf2f0b92537ec41476a6ead45a00b0d8bbb852395a6f9f33f49d6242
+      sha256: b1ce660f4d0dcaffdf2605a19544c129fb5adda4e6fd039992ae356c4e437039
       url: "https://pub.dev"
     source: hosted
-    version: "14.0.0"
+    version: "14.1.0"
   permission_handler_apple:
     dependency: transitive
     description:
@@ -876,10 +876,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
-      sha256: a5c8a97ecf5616112a5b16d4b8e9ec0e5ae90ef63ac69c0d7b8ae240be760b23
+      sha256: ed86a61c190258fdd65de395ea0632822e3415c1faec38eae0c31b479c28a531
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.0"
+    version: "4.4.1"
   permission_handler_windows:
     dependency: transitive
     description:
@@ -1307,10 +1307,10 @@ packages:
     dependency: transitive
     description:
       name: windows_file_picker
-      sha256: "225f58e64c15c2d7b34fb8faf3ca188831967f26b5a723d7c3a7969e41c9b5a5"
+      sha256: d999c1c085374724668af0b674a9758d96255c50933faa2ac1cc51eff8308caf
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   workmanager:
     dependency: "direct main"
     description:
@@ -1384,5 +1384,5 @@ packages:
     source: hosted
     version: "3.1.4"
 sdks:
-  dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.44.0"
+  dart: ">=3.13.0 <4.0.0"
+  flutter: ">=3.47.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,10 +23,10 @@ dependencies:
   html: ^0.15.7
   shared_preferences: ^2.5.5
   url_launcher: ^6.3.2
-  permission_handler: ^13.0.1
+  permission_handler: ^13.0.2
   fluttertoast: ^10.0.0
   device_info_plus: ^13.2.0
-  file_picker: ^12.1.2
+  file_picker: ^12.2.0
   animations: ^3.0.0
   android_package_installer: # TODO: Upstream PR pending; if not accepted, keep fork maintained
     git:
@@ -53,7 +53,7 @@ dependencies:
   bcrypt: ^1.2.0
   app_links: ^7.2.1
   equations: ^6.0.0
-  flex_color_picker: ^3.8.0
+  flex_color_picker: ^4.0.0
   android_system_font: # TODO: Forked dependency; watch upstream for releases
     git:
       url: https://github.com/re7gog/android_system_font
@@ -68,7 +68,7 @@ dependencies:
   flutter_charset_detector: ^6.0.0
   flutter_markdown_plus: ^1.0.12
   workmanager: ^0.10.9
-  logger: ^2.7.0
+  logger: ^2.8.0
 
 dev_dependencies:
   flutter_lints: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: obtainium
 description: Get Android app updates straight from the source.
 publish_to: 'none'
 
-version: 1.6.14+2353
+version: 1.6.15+2354
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
- Handle missing document picker and revoked export-dir grants gracefully (#3227)
- Give TV app list more bottom clearance and stop auto-focusing the add button (#3228)
- Replace dead share action with copy-to-clipboard in log viewer on TV (#3235)
- Stop WorkManager periodic runs when background update checks are disabled (#3272)
- Expose zip APK filter option for Direct APK Link and HTML sources (#3278)