### PR TITLE
docs:README change sig hash formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ Or, contribute some configurations to the website by creating a PR at [this repo
 Verification info:
 
 - Package ID: `dev.imranr.obtainium`
-- SHA-256 hash of signing certificate: 
-```
-B3:53:60:1F:6A:1D:5F:D6:60:3A:E2:F5:0B:E8:0C:F3:01:36:7B:86:B6:AB:8B:1F:66:24:3D:A9:6C:D5:73:62
-```
+- SHA-256 hash of signing certificate:
+  ```text
+  B3:53:60:1F:6A:1D:5F:D6:60:3A:E2:F5:0B:E8:0C:F3:01:36:7B:86:B6:AB:8B:1F:66:24:3D:A9:6C:D5:73:62
+  ```
   - Note: The above signature is also valid for the F-Droid flavour of Obtainium, thanks to [reproducible builds](https://f-droid.org/docs/Reproducible_Builds/).
 - [PGP Public Key](https://keyserver.ubuntu.com/pks/lookup?search=contact%40imranr.dev&fingerprint=on&op=index) (to verify APK hashes)
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ Or, contribute some configurations to the website by creating a PR at [this repo
 Verification info:
 
 - Package ID: `dev.imranr.obtainium`
-- SHA-256 hash of signing certificate: `B3:53:60:1F:6A:1D:5F:D6:60:3A:E2:F5:0B:E8:0C:F3:01:36:7B:86:B6:AB:8B:1F:66:24:3D:A9:6C:D5:73:62`
+- SHA-256 hash of signing certificate: 
+```
+B3:53:60:1F:6A:1D:5F:D6:60:3A:E2:F5:0B:E8:0C:F3:01:36:7B:86:B6:AB:8B:1F:66:24:3D:A9:6C:D5:73:62
+```
   - Note: The above signature is also valid for the F-Droid flavour of Obtainium, thanks to [reproducible builds](https://f-droid.org/docs/Reproducible_Builds/).
 - [PGP Public Key](https://keyserver.ubuntu.com/pks/lookup?search=contact%40imranr.dev&fingerprint=on&op=index) (to verify APK hashes)
 


### PR DESCRIPTION
Minor change to the signature hash checksum formatting; using a code block (```) allows for the copy icon to be shown in github's UI. This improves the UX as it becomes a one-click copy.

Single code (`) formatting does not have this copy feature in github markdown renderer.