### PR TITLE
ci: tighten up auxiliary workflows

### DIFF
--- a/.github/workflows/fastlane.yml
+++ b/.github/workflows/fastlane.yml
@@ -4,8 +4,12 @@ on:
   workflow_dispatch:
   push:
       branches: [ "main" ]
+      paths:
+        - 'fastlane/metadata/android/*'
   pull_request:
       branches: [ "main" ]
+      paths:
+        - 'fastlane/metadata/android/*'
 
 jobs:
   go:

--- a/.github/workflows/translation-validate.yaml
+++ b/.github/workflows/translation-validate.yaml
@@ -3,6 +3,8 @@ name: Validate translation files
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - 'assets/translations/*.json'
 
 jobs:
   validate:


### PR DESCRIPTION
Restrict fastlane.yml and translation-validate.yaml to only run when their files are modified. This should hopefully prevent the action being even prompted, [for example](https://github.com/ImranR98/Obtainium/actions/runs/34722561370).